### PR TITLE
fix: support displaying multiple GPUs in Beszel system detail

### DIFF
--- a/HomelabAndroid/app/src/main/java/com/homelab/app/data/remote/dto/beszel/BeszelDto.kt
+++ b/HomelabAndroid/app/src/main/java/com/homelab/app/data/remote/dto/beszel/BeszelDto.kt
@@ -193,6 +193,10 @@ data class BeszelRecordStats(
     val primaryGpu: BeszelGpuEntry?
         get() = g?.values?.firstOrNull()
 
+    /** All GPU entries sorted by key (e.g. "0", "1", …) */
+    val gpuEntries: List<Map.Entry<String, BeszelGpuEntry>>
+        get() = g?.entries?.sortedBy { it.key } ?: emptyList()
+
     val gpuUsagePercent: Double?
         get() = primaryGpu?.u
 
@@ -207,6 +211,10 @@ data class BeszelRecordStats(
 
     val gpuVramTotalMb: Double?
         get() = primaryGpu?.mt
+
+    fun gpuUsagePercent(key: String): Double? = g?.get(key)?.u
+    fun gpuPowerWatts(key: String): Double? = g?.get(key)?.p
+    fun gpuVramPercent(key: String): Double? = g?.get(key)?.memUsagePercent
 }
 
 @Serializable

--- a/HomelabAndroid/app/src/main/java/com/homelab/app/ui/beszel/BeszelSystemDetailComponents.kt
+++ b/HomelabAndroid/app/src/main/java/com/homelab/app/ui/beszel/BeszelSystemDetailComponents.kt
@@ -837,23 +837,27 @@ internal fun ExtraMetricsSection(
 internal fun GpuMetricsSection(
     latest: BeszelRecordStats,
     history: List<BeszelRecordStats>,
-    onUsageClick: () -> Unit = {},
-    onPowerClick: () -> Unit = {},
-    onVramClick: () -> Unit = {}
+    onGpuMetricClick: (GpuMetricSelection) -> Unit = {}
 ) {
-    val gpu = latest.primaryGpu ?: return
+    val entries = latest.gpuEntries
+    if (entries.isEmpty()) return
 
-    GpuMetricsCard(
-        gpuName = gpu.n,
-        latestUsage = gpu.u ?: 0.0,
-        latestPowerWatts = gpu.p ?: 0.0,
-        latestVramPercent = latest.gpuVramPercent ?: 0.0,
-        latestVramUsedMb = gpu.memUsedMb.takeIf { gpu.mt != null && gpu.mt > 0.0 },
-        latestVramTotalMb = gpu.memTotalMb.takeIf { gpu.mt != null && gpu.mt > 0.0 },
-        onUsageClick = onUsageClick,
-        onPowerClick = onPowerClick,
-        onVramClick = onVramClick
-    )
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        entries.forEach { entry ->
+            val gpu = entry.value
+            GpuMetricsCard(
+                gpuName = gpu.n,
+                latestUsage = gpu.u ?: 0.0,
+                latestPowerWatts = gpu.p ?: 0.0,
+                latestVramPercent = gpu.memUsagePercent ?: 0.0,
+                latestVramUsedMb = gpu.memUsedMb.takeIf { gpu.mt != null && gpu.mt > 0.0 },
+                latestVramTotalMb = gpu.memTotalMb.takeIf { gpu.mt != null && gpu.mt > 0.0 },
+                onUsageClick = { onGpuMetricClick(GpuMetricSelection(GpuMetricType.USAGE, entry.key)) },
+                onPowerClick = { onGpuMetricClick(GpuMetricSelection(GpuMetricType.POWER, entry.key)) },
+                onVramClick = { onGpuMetricClick(GpuMetricSelection(GpuMetricType.VRAM, entry.key)) }
+            )
+        }
+    }
 }
 
 @Composable

--- a/HomelabAndroid/app/src/main/java/com/homelab/app/ui/beszel/BeszelSystemDetailScreen.kt
+++ b/HomelabAndroid/app/src/main/java/com/homelab/app/ui/beszel/BeszelSystemDetailScreen.kt
@@ -134,7 +134,7 @@ private fun BeszelSystemDetailContent(
     val expandedDockerMetric = remember { mutableStateOf<DockerMetricType?>(null) }
     val expandedDiskFs = remember { mutableStateOf<DiskFsUsage?>(null) }
     val expandedSmartDevice = remember { mutableStateOf<BeszelSmartDevice?>(null) }
-    val gpuDetailsMetric = remember { mutableStateOf<GpuMetricType?>(null) }
+    val gpuDetailsSelection = remember { mutableStateOf<GpuMetricSelection?>(null) }
 
     LazyColumn(
         modifier = Modifier
@@ -209,9 +209,7 @@ private fun BeszelSystemDetailContent(
                     GpuMetricsSection(
                         latest = latestStats,
                         history = model.statsHistory,
-                        onUsageClick = { gpuDetailsMetric.value = GpuMetricType.USAGE },
-                        onPowerClick = { gpuDetailsMetric.value = GpuMetricType.POWER },
-                        onVramClick = { gpuDetailsMetric.value = GpuMetricType.VRAM }
+                        onGpuMetricClick = { selection -> gpuDetailsSelection.value = selection }
                     )
                 }
                 item {
@@ -311,11 +309,12 @@ private fun BeszelSystemDetailContent(
         )
     }
 
-    gpuDetailsMetric.value?.let { metric ->
+    gpuDetailsSelection.value?.let { selection ->
         GpuDetailsSheet(
-            metric = metric,
+            metric = selection.metric,
+            gpuKey = selection.gpuKey,
             history = model.statsHistory,
-            onDismiss = { gpuDetailsMetric.value = null }
+            onDismiss = { gpuDetailsSelection.value = null }
         )
     }
 }

--- a/HomelabAndroid/app/src/main/java/com/homelab/app/ui/beszel/BeszelSystemDetailSheets.kt
+++ b/HomelabAndroid/app/src/main/java/com/homelab/app/ui/beszel/BeszelSystemDetailSheets.kt
@@ -435,10 +435,11 @@ internal fun DiskFsDetailsSheet(
 @Composable
 internal fun GpuDetailsSheet(
     metric: GpuMetricType,
+    gpuKey: String,
     history: List<BeszelRecordStats>,
     onDismiss: () -> Unit
 ) {
-    val latestGpu = history.lastOrNull()?.primaryGpu
+    val latestGpu = history.lastOrNull()?.g?.get(gpuKey)
 
     val title: String
     val series: List<Double>
@@ -448,19 +449,19 @@ internal fun GpuDetailsSheet(
     when (metric) {
         GpuMetricType.USAGE -> {
             title = stringResource(R.string.beszel_gpu_usage_label_full)
-            series = history.mapNotNull { it.gpuUsagePercent }.takeLast(240)
+            series = history.mapNotNull { it.gpuUsagePercent(gpuKey) }.takeLast(240)
             accent = ServiceType.BESZEL.primaryColor
             formatter = { v: Double -> String.format("%.0f%%", v) }
         }
         GpuMetricType.POWER -> {
             title = stringResource(R.string.beszel_gpu_power_label_full)
-            series = history.mapNotNull { it.gpuPowerWatts }.takeLast(240)
+            series = history.mapNotNull { it.gpuPowerWatts(gpuKey) }.takeLast(240)
             accent = StatusPurple
             formatter = { v: Double -> String.format("%.1f W", v) }
         }
         GpuMetricType.VRAM -> {
             title = stringResource(R.string.beszel_gpu_vram_label_full)
-            series = history.mapNotNull { it.gpuVramPercent }.takeLast(240)
+            series = history.mapNotNull { it.gpuVramPercent(gpuKey) }.takeLast(240)
             accent = StatusOrange
             formatter = { v: Double -> String.format("%.1f%%", v) }
         }

--- a/HomelabAndroid/app/src/main/java/com/homelab/app/ui/beszel/BeszelSystemDetailTypes.kt
+++ b/HomelabAndroid/app/src/main/java/com/homelab/app/ui/beszel/BeszelSystemDetailTypes.kt
@@ -18,6 +18,11 @@ internal enum class GpuMetricType {
     USAGE, POWER, VRAM
 }
 
+internal data class GpuMetricSelection(
+    val metric: GpuMetricType,
+    val gpuKey: String
+)
+
 internal enum class DockerMetricType {
     CPU, MEMORY, NETWORK
 }

--- a/HomelabSwift/Homelab/Models/Beszel/BeszelModels.swift
+++ b/HomelabSwift/Homelab/Models/Beszel/BeszelModels.swift
@@ -256,11 +256,29 @@ struct BeszelRecordStats: Codable {
         g?.values.first
     }
 
+    /// All GPU entries sorted by key (e.g. "0", "1", …)
+    var gpuEntries: [(key: String, gpu: BeszelGpuEntry)] {
+        guard let g else { return [] }
+        return g.sorted(by: { $0.key < $1.key }).map { (key: $0.key, gpu: $0.value) }
+    }
+
     var gpuUsagePercent: Double? { primaryGpu?.u }
     var gpuPowerWatts: Double? { primaryGpu?.p }
     var gpuVramPercent: Double? { primaryGpu?.memUsagePercent }
     var gpuVramUsedMb: Double? { primaryGpu?.mu }
     var gpuVramTotalMb: Double? { primaryGpu?.mt }
+
+    func gpuUsagePercent(forKey key: String) -> Double? {
+        g?[key]?.u
+    }
+
+    func gpuPowerWatts(forKey key: String) -> Double? {
+        g?[key]?.p
+    }
+
+    func gpuVramPercent(forKey key: String) -> Double? {
+        g?[key]?.memUsagePercent
+    }
 }
 
 // MARK: - GPU Entry

--- a/HomelabSwift/Homelab/Views/Beszel/BeszelDetailComponents.swift
+++ b/HomelabSwift/Homelab/Views/Beszel/BeszelDetailComponents.swift
@@ -168,42 +168,50 @@ struct GpuMetricsSection: View {
     @Binding var expandedGpuMetric: GpuMetricType?
 
     var body: some View {
-        guard let gpu = stats.primaryGpu else { return AnyView(EmptyView()) }
+        let entries = stats.gpuEntries
+        if entries.isEmpty { return AnyView(EmptyView()) }
         return AnyView(
             VStack(alignment: .leading, spacing: 12) {
                 BeszelSectionHeader(icon: "gpu", title: localizer.t.beszelGpu, color: .green)
 
-                VStack(spacing: 0) {
-                    Text(gpu.n)
-                        .font(.caption.bold())
-                        .foregroundStyle(.secondary)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .padding(.horizontal, 16)
-                        .padding(.top, 12)
-
-                    if let usage = gpu.u {
-                        metricRow(icon: "gauge.medium", label: localizer.t.beszelGpuUsage, value: String(format: "%.1f%%", usage),
-                                  progress: usage / 100.0, color: usageColor(usage))
-                        .onTapGesture { expandedGpuMetric = .usage }
-                    }
-                    if let power = gpu.p {
-                        Divider().padding(.leading, 52)
-                        metricRow(icon: "bolt", label: localizer.t.beszelGpuPower, value: String(format: "%.0fW", power),
-                                  progress: nil, color: .orange)
-                        .onTapGesture { expandedGpuMetric = .power }
-                    }
-                    if let vramPct = gpu.memUsagePercent {
-                        Divider().padding(.leading, 52)
-                        metricRow(icon: "memorychip", label: localizer.t.beszelGpuVram,
-                                  value: String(format: "%.0f / %.0f MB (%.0f%%)", gpu.memUsedMb, gpu.memTotalMb, vramPct),
-                                  progress: vramPct / 100.0, color: usageColor(vramPct))
-                        .onTapGesture { expandedGpuMetric = .vram }
-                    }
+                ForEach(entries, id: \.key) { entry in
+                    gpuCard(gpuKey: entry.key, gpu: entry.gpu)
                 }
-                .padding(.bottom, 12)
-                .glassCard()
             }
         )
+    }
+
+    @ViewBuilder
+    private func gpuCard(gpuKey: String, gpu: BeszelGpuEntry) -> some View {
+        VStack(spacing: 0) {
+            Text(gpu.n)
+                .font(.caption.bold())
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 16)
+                .padding(.top, 12)
+
+            if let usage = gpu.u {
+                metricRow(icon: "gauge.medium", label: localizer.t.beszelGpuUsage, value: String(format: "%.1f%%", usage),
+                          progress: usage / 100.0, color: usageColor(usage))
+                .onTapGesture { expandedGpuMetric = .usage(gpuKey: gpuKey) }
+            }
+            if let power = gpu.p {
+                Divider().padding(.leading, 52)
+                metricRow(icon: "bolt", label: localizer.t.beszelGpuPower, value: String(format: "%.0fW", power),
+                          progress: nil, color: .orange)
+                .onTapGesture { expandedGpuMetric = .power(gpuKey: gpuKey) }
+            }
+            if let vramPct = gpu.memUsagePercent {
+                Divider().padding(.leading, 52)
+                metricRow(icon: "memorychip", label: localizer.t.beszelGpuVram,
+                          value: String(format: "%.0f / %.0f MB (%.0f%%)", gpu.memUsedMb, gpu.memTotalMb, vramPct),
+                          progress: vramPct / 100.0, color: usageColor(vramPct))
+                .onTapGesture { expandedGpuMetric = .vram(gpuKey: gpuKey) }
+            }
+        }
+        .padding(.bottom, 12)
+        .glassCard()
     }
 
     private func metricRow(icon: String, label: String, value: String, progress: Double?, color: Color) -> some View {

--- a/HomelabSwift/Homelab/Views/Beszel/BeszelDetailSheets.swift
+++ b/HomelabSwift/Homelab/Views/Beszel/BeszelDetailSheets.swift
@@ -288,11 +288,13 @@ struct GpuDetailSheet: View {
     let records: [BeszelRecordStats]
     let localizer: Localizer
 
+    private var gpuKey: String { metricType.gpuKey }
+
     var body: some View {
         NavigationStack {
             ScrollView {
                 VStack(alignment: .leading, spacing: 16) {
-                    if let gpuName = records.last?.primaryGpu?.n {
+                    if let gpuName = records.last?.g?[gpuKey]?.n {
                         Text(gpuName)
                             .font(.subheadline)
                             .foregroundStyle(.secondary)
@@ -304,15 +306,15 @@ struct GpuDetailSheet: View {
 
                     switch metricType {
                     case .usage:
-                        let _ = (data = records.compactMap(\.gpuUsagePercent),
+                        let _ = (data = records.compactMap { $0.gpuUsagePercent(forKey: gpuKey) },
                                  color = .green,
                                  formatter = { String(format: "%.1f%%", $0) })
                     case .power:
-                        let _ = (data = records.compactMap(\.gpuPowerWatts),
+                        let _ = (data = records.compactMap { $0.gpuPowerWatts(forKey: gpuKey) },
                                  color = .orange,
                                  formatter = { String(format: "%.0fW", $0) })
                     case .vram:
-                        let _ = (data = records.compactMap(\.gpuVramPercent),
+                        let _ = (data = records.compactMap { $0.gpuVramPercent(forKey: gpuKey) },
                                  color = .purple,
                                  formatter = { String(format: "%.1f%%", $0) })
                     }

--- a/HomelabSwift/Homelab/Views/Beszel/BeszelDetailTypes.swift
+++ b/HomelabSwift/Homelab/Views/Beszel/BeszelDetailTypes.swift
@@ -12,9 +12,24 @@ enum ResourceMetricType: String, Identifiable {
     var id: String { rawValue }
 }
 
-enum GpuMetricType: String, Identifiable {
-    case usage, power, vram
-    var id: String { rawValue }
+enum GpuMetricType: Identifiable, Equatable {
+    case usage(gpuKey: String)
+    case power(gpuKey: String)
+    case vram(gpuKey: String)
+
+    var id: String {
+        switch self {
+        case .usage(let key): return "usage_\(key)"
+        case .power(let key): return "power_\(key)"
+        case .vram(let key): return "vram_\(key)"
+        }
+    }
+
+    var gpuKey: String {
+        switch self {
+        case .usage(let key), .power(let key), .vram(let key): return key
+        }
+    }
 }
 
 enum DockerMetricType: String, Identifiable {
@@ -102,7 +117,7 @@ struct BeszelSystemDetailUiModel {
         )
     }
 
-    var hasGpu: Bool { latestStats?.primaryGpu != nil }
+    var hasGpu: Bool { !(latestStats?.gpuEntries.isEmpty ?? true) }
     var hasSmartDevices: Bool { !smartDevices.isEmpty }
     var hasBattery: Bool { latestStats?.batteryLevel != nil }
     var hasSwap: Bool { latestStats?.swapTotalGb != nil }

--- a/HomelabSwift/Homelab/Views/Beszel/BeszelSystemDetail.swift
+++ b/HomelabSwift/Homelab/Views/Beszel/BeszelSystemDetail.swift
@@ -70,7 +70,7 @@ struct BeszelSystemDetail: View {
                     }
 
                     // GPU
-                    if let stats = latestStats, stats.primaryGpu != nil {
+                    if let stats = latestStats, !stats.gpuEntries.isEmpty {
                         GpuMetricsSection(
                             stats: stats,
                             localizer: localizer,


### PR DESCRIPTION
Previously only the first GPU was shown when a system had multiple GPUs. The Beszel API returns GPU data as a map (stats.g) keyed by index, but the app only accessed primaryGpu (first entry).

Changes:
- Add gpuEntries accessor to return all GPUs sorted by key
- Add per-GPU history accessors (gpuUsagePercent/gpuPowerWatts/gpuVramPercent)
- GpuMetricType now carries gpuKey to identify which GPU was tapped
- GpuMetricsSection iterates all GPUs, each rendered as its own card
- GpuDetailSheet filters history data per-GPU using gpuKey
- Consistent implementation across iOS (Swift) and Android (Kotlin)

Screenshots
iOS — Before:
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-25 at 09 25 38" src="https://github.com/user-attachments/assets/a8f3dbe2-88d4-47c9-bd58-b9f9f5b6dc30" />

iOS — After:
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-25 at 09 38 45" src="https://github.com/user-attachments/assets/3676a6bc-98fd-47e0-84f1-017d4b3d9931" />

iOS — Other multi-GPU device:
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-25 at 09 39 23" src="https://github.com/user-attachments/assets/3923772b-6348-4561-bf4d-2ecb522b9b00" />


Android — Before:
![Screenshot_20260325_104355_com_homelab_app_MainActivity](https://github.com/user-attachments/assets/5fb38214-32b5-4427-a028-ecb96e422c39)

Android — After:
![Screenshot_20260325_103353_com_homelab_app_MainActivity](https://github.com/user-attachments/assets/5dfc715f-7892-4985-99b2-12a3ebec9f50)

