### PR TITLE
add 7 new services: jellyfin, immich, grafana, sabnzbd, proxmox, pbs, tdarr

### DIFF
--- a/HomelabAndroid/app/src/main/java/com/homelab/app/data/remote/AuthInterceptor.kt
+++ b/HomelabAndroid/app/src/main/java/com/homelab/app/data/remote/AuthInterceptor.kt
@@ -47,6 +47,18 @@ class AuthInterceptor @Inject constructor(
         if (instance != null) {
             val hasAuthorization = request.header("Authorization") != null
             addAuthHeaders(requestBuilder, instance, hasAuthorization)
+
+            // SABnzbd uses query param auth -- append apikey to URL
+            if (instance.type == com.homelab.app.util.ServiceType.SABNZBD && !instance.apiKey.isNullOrBlank()) {
+                requestBuilder.removeHeader("X-Homelab-SABnzbd-ApiKey")
+                val originalUrl = request.url
+                if (originalUrl.queryParameter("apikey") == null) {
+                    val newUrl = originalUrl.newBuilder()
+                        .addQueryParameter("apikey", instance.apiKey)
+                        .build()
+                    requestBuilder.url(newUrl)
+                }
+            }
         }
 
         request = requestBuilder.build()
@@ -277,6 +289,48 @@ class AuthInterceptor @Inject constructor(
             ServiceType.QBITTORRENT -> {
                 if (instance.token.isNotBlank()) {
                     builder.addHeader("Cookie", "SID=${instance.token}")
+                }
+            }
+            ServiceType.JELLYFIN -> {
+                if (!instance.apiKey.isNullOrBlank()) {
+                    builder.addHeader("X-Emby-Token", instance.apiKey)
+                }
+            }
+            ServiceType.IMMICH -> {
+                if (!instance.apiKey.isNullOrBlank()) {
+                    builder.addHeader("x-api-key", instance.apiKey)
+                }
+            }
+            ServiceType.GRAFANA -> {
+                if (!hasAuthorization && !instance.apiKey.isNullOrBlank()) {
+                    val token = instance.apiKey.trim().let { raw ->
+                        if (raw.startsWith("bearer ", ignoreCase = true)) raw.substring(7).trim() else raw
+                    }
+                    if (token.isNotBlank()) {
+                        builder.addHeader("Authorization", "Bearer $token")
+                    }
+                }
+            }
+            ServiceType.SABNZBD -> {
+                // SABnzbd uses query param auth -- handled at the API layer via interceptor/url rewriting.
+                // The apikey query param is appended by SmartFallbackInterceptor or the API call itself.
+                if (!instance.apiKey.isNullOrBlank()) {
+                    builder.addHeader("X-Homelab-SABnzbd-ApiKey", instance.apiKey)
+                }
+            }
+            ServiceType.PROXMOX -> {
+                if (!hasAuthorization && !instance.apiKey.isNullOrBlank()) {
+                    builder.addHeader("Authorization", "PVEAPIToken=${instance.apiKey}")
+                }
+            }
+            ServiceType.PROXMOX_BACKUP_SERVER -> {
+                if (!hasAuthorization && !instance.apiKey.isNullOrBlank()) {
+                    builder.addHeader("Authorization", "PBSAPIToken=${instance.apiKey}")
+                }
+            }
+            ServiceType.TDARR -> {
+                if (!instance.apiKey.isNullOrBlank()) {
+                    builder.addHeader("x-api-key", instance.apiKey)
                 }
             }
             else -> {}

--- a/HomelabAndroid/app/src/main/java/com/homelab/app/data/remote/api/GrafanaApi.kt
+++ b/HomelabAndroid/app/src/main/java/com/homelab/app/data/remote/api/GrafanaApi.kt
@@ -1,0 +1,27 @@
+package com.homelab.app.data.remote.api
+
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import retrofit2.http.GET
+import retrofit2.http.Header
+
+interface GrafanaApi {
+
+    @GET("api/health")
+    suspend fun getHealth(
+        @Header("X-Homelab-Service") service: String = "Grafana",
+        @Header("X-Homelab-Instance-Id") instanceId: String
+    ): JsonObject
+
+    @GET("api/search")
+    suspend fun searchDashboards(
+        @Header("X-Homelab-Service") service: String = "Grafana",
+        @Header("X-Homelab-Instance-Id") instanceId: String
+    ): JsonArray
+
+    @GET("api/alertmanager/grafana/api/v2/alerts")
+    suspend fun getAlerts(
+        @Header("X-Homelab-Service") service: String = "Grafana",
+        @Header("X-Homelab-Instance-Id") instanceId: String
+    ): JsonArray
+}

--- a/HomelabAndroid/app/src/main/java/com/homelab/app/data/remote/api/ImmichApi.kt
+++ b/HomelabAndroid/app/src/main/java/com/homelab/app/data/remote/api/ImmichApi.kt
@@ -1,0 +1,20 @@
+package com.homelab.app.data.remote.api
+
+import kotlinx.serialization.json.JsonObject
+import retrofit2.http.GET
+import retrofit2.http.Header
+
+interface ImmichApi {
+
+    @GET("api/server/info")
+    suspend fun getServerInfo(
+        @Header("X-Homelab-Service") service: String = "Immich",
+        @Header("X-Homelab-Instance-Id") instanceId: String
+    ): JsonObject
+
+    @GET("api/server/statistics")
+    suspend fun getServerStatistics(
+        @Header("X-Homelab-Service") service: String = "Immich",
+        @Header("X-Homelab-Instance-Id") instanceId: String
+    ): JsonObject
+}

--- a/HomelabAndroid/app/src/main/java/com/homelab/app/data/remote/api/JellyfinApi.kt
+++ b/HomelabAndroid/app/src/main/java/com/homelab/app/data/remote/api/JellyfinApi.kt
@@ -1,0 +1,26 @@
+package com.homelab.app.data.remote.api
+
+import kotlinx.serialization.json.JsonObject
+import retrofit2.http.GET
+import retrofit2.http.Header
+
+interface JellyfinApi {
+
+    @GET("System/Info")
+    suspend fun getSystemInfo(
+        @Header("X-Homelab-Service") service: String = "Jellyfin",
+        @Header("X-Homelab-Instance-Id") instanceId: String
+    ): JsonObject
+
+    @GET("Sessions")
+    suspend fun getSessions(
+        @Header("X-Homelab-Service") service: String = "Jellyfin",
+        @Header("X-Homelab-Instance-Id") instanceId: String
+    ): kotlinx.serialization.json.JsonArray
+
+    @GET("Items")
+    suspend fun getItems(
+        @Header("X-Homelab-Service") service: String = "Jellyfin",
+        @Header("X-Homelab-Instance-Id") instanceId: String
+    ): JsonObject
+}

--- a/HomelabAndroid/app/src/main/java/com/homelab/app/data/remote/api/PBSApi.kt
+++ b/HomelabAndroid/app/src/main/java/com/homelab/app/data/remote/api/PBSApi.kt
@@ -1,0 +1,20 @@
+package com.homelab.app.data.remote.api
+
+import kotlinx.serialization.json.JsonObject
+import retrofit2.http.GET
+import retrofit2.http.Header
+
+interface PBSApi {
+
+    @GET("api2/json/admin/datastore")
+    suspend fun getDatastores(
+        @Header("X-Homelab-Service") service: String = "PBS",
+        @Header("X-Homelab-Instance-Id") instanceId: String
+    ): JsonObject
+
+    @GET("api2/json/status/datastore-usage")
+    suspend fun getDatastoreUsage(
+        @Header("X-Homelab-Service") service: String = "PBS",
+        @Header("X-Homelab-Instance-Id") instanceId: String
+    ): JsonObject
+}

--- a/HomelabAndroid/app/src/main/java/com/homelab/app/data/remote/api/ProxmoxApi.kt
+++ b/HomelabAndroid/app/src/main/java/com/homelab/app/data/remote/api/ProxmoxApi.kt
@@ -1,0 +1,20 @@
+package com.homelab.app.data.remote.api
+
+import kotlinx.serialization.json.JsonObject
+import retrofit2.http.GET
+import retrofit2.http.Header
+
+interface ProxmoxApi {
+
+    @GET("api2/json/nodes")
+    suspend fun getNodes(
+        @Header("X-Homelab-Service") service: String = "Proxmox",
+        @Header("X-Homelab-Instance-Id") instanceId: String
+    ): JsonObject
+
+    @GET("api2/json/cluster/resources")
+    suspend fun getClusterResources(
+        @Header("X-Homelab-Service") service: String = "Proxmox",
+        @Header("X-Homelab-Instance-Id") instanceId: String
+    ): JsonObject
+}

--- a/HomelabAndroid/app/src/main/java/com/homelab/app/data/remote/api/SABnzbdApi.kt
+++ b/HomelabAndroid/app/src/main/java/com/homelab/app/data/remote/api/SABnzbdApi.kt
@@ -1,0 +1,26 @@
+package com.homelab.app.data.remote.api
+
+import kotlinx.serialization.json.JsonObject
+import retrofit2.http.GET
+import retrofit2.http.Header
+import retrofit2.http.Query
+
+interface SABnzbdApi {
+
+    @GET("api")
+    suspend fun getQueue(
+        @Header("X-Homelab-Service") service: String = "SABnzbd",
+        @Header("X-Homelab-Instance-Id") instanceId: String,
+        @Query("mode") mode: String = "queue",
+        @Query("output") output: String = "json"
+    ): JsonObject
+
+    @GET("api")
+    suspend fun getHistory(
+        @Header("X-Homelab-Service") service: String = "SABnzbd",
+        @Header("X-Homelab-Instance-Id") instanceId: String,
+        @Query("mode") mode: String = "history",
+        @Query("output") output: String = "json",
+        @Query("limit") limit: Int = 30
+    ): JsonObject
+}

--- a/HomelabAndroid/app/src/main/java/com/homelab/app/data/remote/api/TdarrApi.kt
+++ b/HomelabAndroid/app/src/main/java/com/homelab/app/data/remote/api/TdarrApi.kt
@@ -1,0 +1,23 @@
+package com.homelab.app.data.remote.api
+
+import kotlinx.serialization.json.JsonObject
+import retrofit2.http.Body
+import retrofit2.http.Header
+import retrofit2.http.POST
+
+interface TdarrApi {
+
+    @POST("api/v2/get-nodes")
+    suspend fun getNodes(
+        @Header("X-Homelab-Service") service: String = "Tdarr",
+        @Header("X-Homelab-Instance-Id") instanceId: String,
+        @Body body: JsonObject = JsonObject(emptyMap())
+    ): JsonObject
+
+    @POST("api/v2/get-stats")
+    suspend fun getStats(
+        @Header("X-Homelab-Service") service: String = "Tdarr",
+        @Header("X-Homelab-Instance-Id") instanceId: String,
+        @Body body: JsonObject = JsonObject(emptyMap())
+    ): JsonObject
+}

--- a/HomelabAndroid/app/src/main/java/com/homelab/app/data/repository/GrafanaRepository.kt
+++ b/HomelabAndroid/app/src/main/java/com/homelab/app/data/repository/GrafanaRepository.kt
@@ -1,0 +1,142 @@
+package com.homelab.app.data.repository
+
+import com.homelab.app.data.remote.api.GrafanaApi
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import okhttp3.OkHttpClient
+import okhttp3.Request
+
+data class GrafanaDashboardData(
+    val version: String,
+    val database: String,
+    val commit: String,
+    val dashboardCount: Int,
+    val alertCount: Int,
+    val firingAlerts: Int,
+    val dashboards: List<GrafanaDashboardItem>,
+    val alerts: List<GrafanaAlert>
+)
+
+data class GrafanaDashboardItem(
+    val id: Int,
+    val uid: String,
+    val title: String,
+    val type: String,
+    val uri: String?,
+    val tags: List<String>
+)
+
+data class GrafanaAlert(
+    val name: String,
+    val state: String,
+    val severity: String?
+)
+
+@Singleton
+class GrafanaRepository @Inject constructor(
+    private val api: GrafanaApi,
+    private val okHttpClient: OkHttpClient
+) {
+
+    suspend fun authenticate(url: String, apiKey: String) {
+        withContext(Dispatchers.IO) {
+            val clean = cleanUrl(url)
+            val key = apiKey.trim()
+            val bearerToken = if (key.startsWith("bearer ", ignoreCase = true)) key else "Bearer $key"
+            val request = Request.Builder()
+                .url("$clean/api/health")
+                .addHeader("Authorization", bearerToken)
+                .addHeader("Accept", "application/json")
+                .build()
+
+            okHttpClient.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) {
+                    throw IllegalStateException("Grafana authentication failed")
+                }
+            }
+        }
+    }
+
+    suspend fun getDashboard(instanceId: String): GrafanaDashboardData = coroutineScope {
+        val healthDef = async { api.getHealth(instanceId = instanceId) }
+        val dashboardsDef = async { api.searchDashboards(instanceId = instanceId) }
+        val alertsDef = async {
+            try {
+                api.getAlerts(instanceId = instanceId)
+            } catch (_: Exception) {
+                JsonArray(emptyList())
+            }
+        }
+
+        val health = healthDef.await()
+        val dashboardsArray = dashboardsDef.await()
+        val alertsArray = alertsDef.await()
+
+        val version = health.str("version") ?: "Unknown"
+        val database = health.str("database") ?: "Unknown"
+        val commit = health.str("commit") ?: "Unknown"
+
+        val dashboards = dashboardsArray.mapNotNull { element ->
+            val obj = element as? JsonObject ?: return@mapNotNull null
+            GrafanaDashboardItem(
+                id = obj.int("id"),
+                uid = obj.str("uid") ?: "",
+                title = obj.str("title") ?: "Untitled",
+                type = obj.str("type") ?: "dash-db",
+                uri = obj.str("uri"),
+                tags = (obj["tags"] as? JsonArray)?.mapNotNull { (it as? JsonPrimitive)?.content } ?: emptyList()
+            )
+        }
+
+        val alerts = alertsArray.mapNotNull { element ->
+            val obj = element as? JsonObject ?: return@mapNotNull null
+            val labels = obj["labels"] as? JsonObject
+            GrafanaAlert(
+                name = labels?.str("alertname") ?: obj.str("name") ?: "Unknown",
+                state = obj.str("state") ?: (obj["status"] as? JsonObject)?.str("state") ?: "unknown",
+                severity = labels?.str("severity")
+            )
+        }
+
+        val firingAlerts = alerts.count { it.state.equals("active", ignoreCase = true) || it.state.equals("firing", ignoreCase = true) }
+
+        GrafanaDashboardData(
+            version = version,
+            database = database,
+            commit = commit,
+            dashboardCount = dashboards.size,
+            alertCount = alerts.size,
+            firingAlerts = firingAlerts,
+            dashboards = dashboards,
+            alerts = alerts
+        )
+    }
+
+    private fun cleanUrl(raw: String): String {
+        var clean = raw.trim()
+        if (!clean.startsWith("http://") && !clean.startsWith("https://")) {
+            clean = "https://$clean"
+        }
+        return clean.replace(Regex("/+$"), "")
+    }
+}
+
+private fun JsonObject.str(key: String): String? {
+    val element = this[key] ?: return null
+    val primitive = element as? JsonPrimitive ?: return null
+    val content = primitive.content
+    return if (content.equals("null", ignoreCase = true)) null else content
+}
+
+private fun JsonObject.int(key: String): Int {
+    val element = this[key] ?: return 0
+    val primitive = element as? JsonPrimitive ?: return 0
+    return primitive.content.toIntOrNull() ?: 0
+}

--- a/HomelabAndroid/app/src/main/java/com/homelab/app/data/repository/ImmichRepository.kt
+++ b/HomelabAndroid/app/src/main/java/com/homelab/app/data/repository/ImmichRepository.kt
@@ -1,0 +1,105 @@
+package com.homelab.app.data.repository
+
+import com.homelab.app.data.remote.api.ImmichApi
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import okhttp3.OkHttpClient
+import okhttp3.Request
+
+data class ImmichDashboardData(
+    val version: String,
+    val totalPhotos: Int,
+    val totalVideos: Int,
+    val totalUsage: Long,
+    val totalUsers: Int
+)
+
+@Singleton
+class ImmichRepository @Inject constructor(
+    private val api: ImmichApi,
+    private val okHttpClient: OkHttpClient
+) {
+
+    suspend fun authenticate(url: String, apiKey: String) {
+        withContext(Dispatchers.IO) {
+            val clean = cleanUrl(url)
+            val key = apiKey.trim()
+            val request = Request.Builder()
+                .url("$clean/api/server/info")
+                .addHeader("x-api-key", key)
+                .addHeader("Accept", "application/json")
+                .build()
+
+            okHttpClient.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) {
+                    throw IllegalStateException("Immich authentication failed")
+                }
+            }
+        }
+    }
+
+    suspend fun getDashboard(instanceId: String): ImmichDashboardData = coroutineScope {
+        val serverInfoDef = async { api.getServerInfo(instanceId = instanceId) }
+        val statsDef = async {
+            try {
+                api.getServerStatistics(instanceId = instanceId)
+            } catch (_: Exception) {
+                null
+            }
+        }
+
+        val serverInfo = serverInfoDef.await()
+        val stats = statsDef.await()
+
+        val version = serverInfo.str("version") ?: "Unknown"
+
+        val totalPhotos = stats?.int("photos") ?: 0
+        val totalVideos = stats?.int("videos") ?: 0
+        val totalUsage = stats?.long("usage") ?: 0L
+        val totalUsers = stats?.int("usageByUser")?.let { 0 }
+            ?: (stats?.get("usageByUser") as? kotlinx.serialization.json.JsonArray)?.size
+            ?: 0
+
+        ImmichDashboardData(
+            version = version,
+            totalPhotos = totalPhotos,
+            totalVideos = totalVideos,
+            totalUsage = totalUsage,
+            totalUsers = totalUsers
+        )
+    }
+
+    private fun cleanUrl(raw: String): String {
+        var clean = raw.trim()
+        if (!clean.startsWith("http://") && !clean.startsWith("https://")) {
+            clean = "https://$clean"
+        }
+        return clean.replace(Regex("/+$"), "")
+    }
+}
+
+private fun JsonObject.str(key: String): String? {
+    val element = this[key] ?: return null
+    val primitive = element as? JsonPrimitive ?: return null
+    val content = primitive.content
+    return if (content.equals("null", ignoreCase = true)) null else content
+}
+
+private fun JsonObject.int(key: String): Int {
+    val element = this[key] ?: return 0
+    val primitive = element as? JsonPrimitive ?: return 0
+    return primitive.content.toIntOrNull() ?: 0
+}
+
+private fun JsonObject.long(key: String): Long {
+    val element = this[key] ?: return 0L
+    val primitive = element as? JsonPrimitive ?: return 0L
+    return primitive.content.toLongOrNull() ?: 0L
+}

--- a/HomelabAndroid/app/src/main/java/com/homelab/app/data/repository/JellyfinRepository.kt
+++ b/HomelabAndroid/app/src/main/java/com/homelab/app/data/repository/JellyfinRepository.kt
@@ -1,0 +1,126 @@
+package com.homelab.app.data.repository
+
+import com.homelab.app.data.remote.api.JellyfinApi
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import okhttp3.OkHttpClient
+import okhttp3.Request
+
+data class JellyfinDashboardData(
+    val serverName: String,
+    val version: String,
+    val operatingSystem: String,
+    val activeSessions: Int,
+    val activeStreams: Int,
+    val totalItems: Int,
+    val sessions: List<JellyfinSession>
+)
+
+data class JellyfinSession(
+    val id: String,
+    val userName: String,
+    val client: String,
+    val deviceName: String,
+    val nowPlayingTitle: String?,
+    val nowPlayingType: String?,
+    val isActive: Boolean
+)
+
+@Singleton
+class JellyfinRepository @Inject constructor(
+    private val api: JellyfinApi,
+    private val okHttpClient: OkHttpClient
+) {
+
+    suspend fun authenticate(url: String, apiKey: String) {
+        withContext(Dispatchers.IO) {
+            val clean = cleanUrl(url)
+            val key = apiKey.trim()
+            val request = Request.Builder()
+                .url("$clean/System/Info")
+                .addHeader("X-Emby-Token", key)
+                .addHeader("Accept", "application/json")
+                .build()
+
+            okHttpClient.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) {
+                    throw IllegalStateException("Jellyfin authentication failed")
+                }
+            }
+        }
+    }
+
+    suspend fun getDashboard(instanceId: String): JellyfinDashboardData = coroutineScope {
+        val systemInfoDef = async { api.getSystemInfo(instanceId = instanceId) }
+        val sessionsDef = async { api.getSessions(instanceId = instanceId) }
+        val itemsDef = async {
+            try {
+                api.getItems(instanceId = instanceId)
+            } catch (_: Exception) {
+                null
+            }
+        }
+
+        val systemInfo = systemInfoDef.await()
+        val sessionsArray = sessionsDef.await()
+        val itemsResponse = itemsDef.await()
+
+        val serverName = systemInfo.str("ServerName") ?: "Jellyfin"
+        val version = systemInfo.str("Version") ?: "Unknown"
+        val os = systemInfo.str("OperatingSystem") ?: "Unknown"
+
+        val sessions = sessionsArray.mapNotNull { element ->
+            val obj = element as? JsonObject ?: return@mapNotNull null
+            val nowPlaying = obj["NowPlayingItem"] as? JsonObject
+            JellyfinSession(
+                id = obj.str("Id") ?: return@mapNotNull null,
+                userName = obj.str("UserName") ?: "Unknown",
+                client = obj.str("Client") ?: "Unknown",
+                deviceName = obj.str("DeviceName") ?: "Unknown",
+                nowPlayingTitle = nowPlaying?.str("Name"),
+                nowPlayingType = nowPlaying?.str("Type"),
+                isActive = nowPlaying != null
+            )
+        }
+
+        val totalItems = itemsResponse?.get("TotalRecordCount")?.asInt() ?: 0
+
+        JellyfinDashboardData(
+            serverName = serverName,
+            version = version,
+            operatingSystem = os,
+            activeSessions = sessions.size,
+            activeStreams = sessions.count { it.isActive },
+            totalItems = totalItems,
+            sessions = sessions
+        )
+    }
+
+    private fun cleanUrl(raw: String): String {
+        var clean = raw.trim()
+        if (!clean.startsWith("http://") && !clean.startsWith("https://")) {
+            clean = "https://$clean"
+        }
+        return clean.replace(Regex("/+$"), "")
+    }
+}
+
+private fun JsonObject.str(key: String): String? {
+    val element = this[key] ?: return null
+    val primitive = element as? JsonPrimitive ?: return null
+    val content = primitive.content
+    return if (content.equals("null", ignoreCase = true)) null else content
+}
+
+private fun JsonElement?.asInt(): Int {
+    val primitive = this as? JsonPrimitive ?: return 0
+    return primitive.content.toIntOrNull() ?: 0
+}

--- a/HomelabAndroid/app/src/main/java/com/homelab/app/data/repository/MediaArrRepository.kt
+++ b/HomelabAndroid/app/src/main/java/com/homelab/app/data/repository/MediaArrRepository.kt
@@ -323,6 +323,18 @@ class MediaArrRepository @Inject constructor(
             ServiceType.BAZARR -> bazarrSnapshot(instance)
             ServiceType.GLUETUN -> gluetunSnapshot(instance)
             ServiceType.FLARESOLVERR -> flaresolverrSnapshot(instance)
+            ServiceType.JELLYFIN,
+            ServiceType.SABNZBD,
+            ServiceType.TDARR -> MediaArrSnapshot(
+                serviceType = instance.type,
+                serviceLabel = instance.label,
+                version = null,
+                status = null,
+                metrics = emptyList(),
+                highlights = emptyList(),
+                warnings = emptyList(),
+                actions = emptyList()
+            )
             else -> throw IllegalStateException("Unsupported media service: ${instance.type.displayName}")
         }
     }
@@ -340,6 +352,13 @@ class MediaArrRepository @Inject constructor(
             ServiceType.BAZARR -> bazarrCardPreview(instance)
             ServiceType.GLUETUN -> gluetunCardPreview(instance)
             ServiceType.FLARESOLVERR -> flaresolverrCardPreview(instance)
+            ServiceType.JELLYFIN,
+            ServiceType.SABNZBD,
+            ServiceType.TDARR -> MediaArrCardPreview(
+                serviceType = instance.type,
+                headline = null,
+                metrics = emptyList()
+            )
             else -> throw IllegalStateException("Unsupported media service: ${instance.type.displayName}")
         }
     }

--- a/HomelabAndroid/app/src/main/java/com/homelab/app/data/repository/PBSRepository.kt
+++ b/HomelabAndroid/app/src/main/java/com/homelab/app/data/repository/PBSRepository.kt
@@ -1,0 +1,119 @@
+package com.homelab.app.data.repository
+
+import com.homelab.app.data.remote.api.PBSApi
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import okhttp3.OkHttpClient
+import okhttp3.Request
+
+data class PBSDashboardData(
+    val datastores: List<PBSDatastore>,
+    val datastoreUsage: List<PBSDatastoreUsage>
+)
+
+data class PBSDatastore(
+    val name: String,
+    val path: String?,
+    val comment: String?
+)
+
+data class PBSDatastoreUsage(
+    val store: String,
+    val total: Long,
+    val used: Long,
+    val available: Long
+)
+
+@Singleton
+class PBSRepository @Inject constructor(
+    private val api: PBSApi,
+    private val okHttpClient: OkHttpClient
+) {
+
+    suspend fun authenticate(url: String, apiKey: String) {
+        withContext(Dispatchers.IO) {
+            val clean = cleanUrl(url)
+            val key = apiKey.trim()
+            val request = Request.Builder()
+                .url("$clean/api2/json/admin/datastore")
+                .addHeader("Authorization", "PBSAPIToken=$key")
+                .addHeader("Accept", "application/json")
+                .build()
+
+            okHttpClient.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) {
+                    throw IllegalStateException("PBS authentication failed")
+                }
+            }
+        }
+    }
+
+    suspend fun getDashboard(instanceId: String): PBSDashboardData = coroutineScope {
+        val datastoresDef = async { api.getDatastores(instanceId = instanceId) }
+        val usageDef = async {
+            try {
+                api.getDatastoreUsage(instanceId = instanceId)
+            } catch (_: Exception) {
+                null
+            }
+        }
+
+        val datastoresResponse = datastoresDef.await()
+        val usageResponse = usageDef.await()
+
+        val datastoresArray = (datastoresResponse["data"] as? JsonArray) ?: JsonArray(emptyList())
+        val usageArray = (usageResponse?.get("data") as? JsonArray) ?: JsonArray(emptyList())
+
+        val datastores = datastoresArray.mapNotNull { element ->
+            val obj = element as? JsonObject ?: return@mapNotNull null
+            PBSDatastore(
+                name = obj.str("name") ?: return@mapNotNull null,
+                path = obj.str("path"),
+                comment = obj.str("comment")
+            )
+        }
+
+        val usageItems = usageArray.mapNotNull { element ->
+            val obj = element as? JsonObject ?: return@mapNotNull null
+            PBSDatastoreUsage(
+                store = obj.str("store") ?: return@mapNotNull null,
+                total = obj.long("total"),
+                used = obj.long("used"),
+                available = obj.long("avail")
+            )
+        }
+
+        PBSDashboardData(
+            datastores = datastores,
+            datastoreUsage = usageItems
+        )
+    }
+
+    private fun cleanUrl(raw: String): String {
+        var clean = raw.trim()
+        if (!clean.startsWith("http://") && !clean.startsWith("https://")) {
+            clean = "https://$clean"
+        }
+        return clean.replace(Regex("/+$"), "")
+    }
+}
+
+private fun JsonObject.str(key: String): String? {
+    val element = this[key] ?: return null
+    val primitive = element as? JsonPrimitive ?: return null
+    val content = primitive.content
+    return if (content.equals("null", ignoreCase = true)) null else content
+}
+
+private fun JsonObject.long(key: String): Long {
+    val element = this[key] ?: return 0L
+    val primitive = element as? JsonPrimitive ?: return 0L
+    return primitive.content.toLongOrNull() ?: primitive.content.toDoubleOrNull()?.toLong() ?: 0L
+}

--- a/HomelabAndroid/app/src/main/java/com/homelab/app/data/repository/ProxmoxRepository.kt
+++ b/HomelabAndroid/app/src/main/java/com/homelab/app/data/repository/ProxmoxRepository.kt
@@ -1,0 +1,146 @@
+package com.homelab.app.data.repository
+
+import com.homelab.app.data.remote.api.ProxmoxApi
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import okhttp3.OkHttpClient
+import okhttp3.Request
+
+data class ProxmoxDashboardData(
+    val nodes: List<ProxmoxNode>,
+    val resources: List<ProxmoxResource>,
+    val totalVMs: Int,
+    val runningVMs: Int,
+    val totalContainers: Int,
+    val runningContainers: Int
+)
+
+data class ProxmoxNode(
+    val node: String,
+    val status: String,
+    val cpuUsage: Double,
+    val memoryUsed: Long,
+    val memoryTotal: Long,
+    val uptime: Long
+)
+
+data class ProxmoxResource(
+    val id: String,
+    val name: String,
+    val type: String,
+    val status: String,
+    val node: String,
+    val cpuUsage: Double,
+    val memoryUsed: Long,
+    val memoryTotal: Long
+)
+
+@Singleton
+class ProxmoxRepository @Inject constructor(
+    private val api: ProxmoxApi,
+    private val okHttpClient: OkHttpClient
+) {
+
+    suspend fun authenticate(url: String, apiKey: String) {
+        withContext(Dispatchers.IO) {
+            val clean = cleanUrl(url)
+            val key = apiKey.trim()
+            val request = Request.Builder()
+                .url("$clean/api2/json/nodes")
+                .addHeader("Authorization", "PVEAPIToken=$key")
+                .addHeader("Accept", "application/json")
+                .build()
+
+            okHttpClient.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) {
+                    throw IllegalStateException("Proxmox authentication failed")
+                }
+            }
+        }
+    }
+
+    suspend fun getDashboard(instanceId: String): ProxmoxDashboardData = coroutineScope {
+        val nodesDef = async { api.getNodes(instanceId = instanceId) }
+        val resourcesDef = async { api.getClusterResources(instanceId = instanceId) }
+
+        val nodesResponse = nodesDef.await()
+        val resourcesResponse = resourcesDef.await()
+
+        val nodesArray = (nodesResponse["data"] as? JsonArray) ?: JsonArray(emptyList())
+        val resourcesArray = (resourcesResponse["data"] as? JsonArray) ?: JsonArray(emptyList())
+
+        val nodes = nodesArray.mapNotNull { element ->
+            val obj = element as? JsonObject ?: return@mapNotNull null
+            ProxmoxNode(
+                node = obj.str("node") ?: return@mapNotNull null,
+                status = obj.str("status") ?: "unknown",
+                cpuUsage = obj.double("cpu"),
+                memoryUsed = obj.long("mem"),
+                memoryTotal = obj.long("maxmem"),
+                uptime = obj.long("uptime")
+            )
+        }
+
+        val resources = resourcesArray.mapNotNull { element ->
+            val obj = element as? JsonObject ?: return@mapNotNull null
+            val type = obj.str("type") ?: return@mapNotNull null
+            if (type != "qemu" && type != "lxc") return@mapNotNull null
+            ProxmoxResource(
+                id = obj.str("id") ?: return@mapNotNull null,
+                name = obj.str("name") ?: "Unknown",
+                type = type,
+                status = obj.str("status") ?: "unknown",
+                node = obj.str("node") ?: "unknown",
+                cpuUsage = obj.double("cpu"),
+                memoryUsed = obj.long("mem"),
+                memoryTotal = obj.long("maxmem")
+            )
+        }
+
+        val vms = resources.filter { it.type == "qemu" }
+        val containers = resources.filter { it.type == "lxc" }
+
+        ProxmoxDashboardData(
+            nodes = nodes,
+            resources = resources,
+            totalVMs = vms.size,
+            runningVMs = vms.count { it.status == "running" },
+            totalContainers = containers.size,
+            runningContainers = containers.count { it.status == "running" }
+        )
+    }
+
+    private fun cleanUrl(raw: String): String {
+        var clean = raw.trim()
+        if (!clean.startsWith("http://") && !clean.startsWith("https://")) {
+            clean = "https://$clean"
+        }
+        return clean.replace(Regex("/+$"), "")
+    }
+}
+
+private fun JsonObject.str(key: String): String? {
+    val element = this[key] ?: return null
+    val primitive = element as? JsonPrimitive ?: return null
+    val content = primitive.content
+    return if (content.equals("null", ignoreCase = true)) null else content
+}
+
+private fun JsonObject.long(key: String): Long {
+    val element = this[key] ?: return 0L
+    val primitive = element as? JsonPrimitive ?: return 0L
+    return primitive.content.toLongOrNull() ?: primitive.content.toDoubleOrNull()?.toLong() ?: 0L
+}
+
+private fun JsonObject.double(key: String): Double {
+    val element = this[key] ?: return 0.0
+    val primitive = element as? JsonPrimitive ?: return 0.0
+    return primitive.content.toDoubleOrNull() ?: 0.0
+}

--- a/HomelabAndroid/app/src/main/java/com/homelab/app/data/repository/SABnzbdRepository.kt
+++ b/HomelabAndroid/app/src/main/java/com/homelab/app/data/repository/SABnzbdRepository.kt
@@ -1,0 +1,147 @@
+package com.homelab.app.data.repository
+
+import com.homelab.app.data.remote.api.SABnzbdApi
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import okhttp3.OkHttpClient
+import okhttp3.Request
+
+data class SABnzbdDashboardData(
+    val version: String,
+    val paused: Boolean,
+    val speedBps: String,
+    val sizeLeft: String,
+    val timeLeft: String,
+    val diskSpaceFree: String,
+    val queueCount: Int,
+    val historyCount: Int,
+    val queueItems: List<SABnzbdQueueItem>,
+    val historyItems: List<SABnzbdHistoryItem>
+)
+
+data class SABnzbdQueueItem(
+    val id: String,
+    val filename: String,
+    val status: String,
+    val percentage: Int,
+    val sizeLeft: String,
+    val timeLeft: String
+)
+
+data class SABnzbdHistoryItem(
+    val id: String,
+    val name: String,
+    val status: String,
+    val size: String,
+    val completedAt: Long
+)
+
+@Singleton
+class SABnzbdRepository @Inject constructor(
+    private val api: SABnzbdApi,
+    private val okHttpClient: OkHttpClient
+) {
+
+    suspend fun authenticate(url: String, apiKey: String) {
+        withContext(Dispatchers.IO) {
+            val clean = cleanUrl(url)
+            val key = apiKey.trim()
+            val request = Request.Builder()
+                .url("$clean/api?mode=queue&output=json&apikey=$key")
+                .addHeader("Accept", "application/json")
+                .build()
+
+            okHttpClient.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) {
+                    throw IllegalStateException("SABnzbd authentication failed")
+                }
+            }
+        }
+    }
+
+    suspend fun getDashboard(instanceId: String): SABnzbdDashboardData = coroutineScope {
+        val queueDef = async { api.getQueue(instanceId = instanceId) }
+        val historyDef = async { api.getHistory(instanceId = instanceId) }
+
+        val queueResponse = queueDef.await()
+        val historyResponse = historyDef.await()
+
+        val queue = queueResponse["queue"] as? JsonObject ?: JsonObject(emptyMap())
+        val history = historyResponse["history"] as? JsonObject ?: JsonObject(emptyMap())
+
+        val version = queue.str("version") ?: "Unknown"
+        val paused = queue.str("paused")?.toBooleanStrictOrNull() ?: false
+        val speed = queue.str("speed") ?: "0 B/s"
+        val sizeLeft = queue.str("sizeleft") ?: "0 B"
+        val timeLeft = queue.str("timeleft") ?: "0:00:00"
+        val diskFree = queue.str("diskspacef1") ?: "Unknown"
+
+        val slots = (queue["slots"] as? JsonArray) ?: JsonArray(emptyList())
+        val queueItems = slots.mapNotNull { element ->
+            val obj = element as? JsonObject ?: return@mapNotNull null
+            SABnzbdQueueItem(
+                id = obj.str("nzo_id") ?: return@mapNotNull null,
+                filename = obj.str("filename") ?: "Unknown",
+                status = obj.str("status") ?: "Unknown",
+                percentage = obj.str("percentage")?.toIntOrNull() ?: 0,
+                sizeLeft = obj.str("sizeleft") ?: "0 B",
+                timeLeft = obj.str("timeleft") ?: ""
+            )
+        }
+
+        val historySlots = (history["slots"] as? JsonArray) ?: JsonArray(emptyList())
+        val historyItems = historySlots.mapNotNull { element ->
+            val obj = element as? JsonObject ?: return@mapNotNull null
+            SABnzbdHistoryItem(
+                id = obj.str("nzo_id") ?: return@mapNotNull null,
+                name = obj.str("name") ?: "Unknown",
+                status = obj.str("status") ?: "Unknown",
+                size = obj.str("size") ?: "0 B",
+                completedAt = obj.long("completed") * 1000L
+            )
+        }
+
+        val historyCount = history.str("noofslots")?.toIntOrNull() ?: historyItems.size
+
+        SABnzbdDashboardData(
+            version = version,
+            paused = paused,
+            speedBps = speed,
+            sizeLeft = sizeLeft,
+            timeLeft = timeLeft,
+            diskSpaceFree = diskFree,
+            queueCount = queueItems.size,
+            historyCount = historyCount,
+            queueItems = queueItems,
+            historyItems = historyItems
+        )
+    }
+
+    private fun cleanUrl(raw: String): String {
+        var clean = raw.trim()
+        if (!clean.startsWith("http://") && !clean.startsWith("https://")) {
+            clean = "https://$clean"
+        }
+        return clean.replace(Regex("/+$"), "")
+    }
+}
+
+private fun JsonObject.str(key: String): String? {
+    val element = this[key] ?: return null
+    val primitive = element as? JsonPrimitive ?: return null
+    val content = primitive.content
+    return if (content.equals("null", ignoreCase = true)) null else content
+}
+
+private fun JsonObject.long(key: String): Long {
+    val element = this[key] ?: return 0L
+    val primitive = element as? JsonPrimitive ?: return 0L
+    return primitive.content.toLongOrNull() ?: 0L
+}

--- a/HomelabAndroid/app/src/main/java/com/homelab/app/data/repository/TdarrRepository.kt
+++ b/HomelabAndroid/app/src/main/java/com/homelab/app/data/repository/TdarrRepository.kt
@@ -1,0 +1,119 @@
+package com.homelab.app.data.repository
+
+import com.homelab.app.data.remote.api.TdarrApi
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+
+data class TdarrDashboardData(
+    val totalFiles: Int,
+    val totalTranscodeCount: Int,
+    val totalHealthCheckCount: Int,
+    val sizeReduction: String,
+    val nodes: List<TdarrNode>,
+    val tdarrScore: String
+)
+
+data class TdarrNode(
+    val id: String,
+    val name: String,
+    val workers: Int,
+    val online: Boolean
+)
+
+@Singleton
+class TdarrRepository @Inject constructor(
+    private val api: TdarrApi,
+    private val okHttpClient: OkHttpClient
+) {
+
+    suspend fun authenticate(url: String, apiKey: String) {
+        withContext(Dispatchers.IO) {
+            val clean = cleanUrl(url)
+            val requestBuilder = Request.Builder()
+                .url("$clean/api/v2/get-stats")
+                .post("{}".toRequestBody("application/json".toMediaType()))
+                .addHeader("Accept", "application/json")
+                .addHeader("Content-Type", "application/json")
+
+            if (apiKey.isNotBlank()) {
+                requestBuilder.addHeader("x-api-key", apiKey.trim())
+            }
+
+            okHttpClient.newCall(requestBuilder.build()).execute().use { response ->
+                if (!response.isSuccessful) {
+                    throw IllegalStateException("Tdarr authentication failed")
+                }
+            }
+        }
+    }
+
+    suspend fun getDashboard(instanceId: String): TdarrDashboardData = coroutineScope {
+        val statsDef = async { api.getStats(instanceId = instanceId) }
+        val nodesDef = async {
+            try {
+                api.getNodes(instanceId = instanceId)
+            } catch (_: Exception) {
+                null
+            }
+        }
+
+        val stats = statsDef.await()
+        val nodesObj = nodesDef.await()
+
+        val totalFiles = stats.int("totalFileCount")
+        val totalTranscodeCount = stats.int("totalTranscodeCount")
+        val totalHealthCheckCount = stats.int("totalHealthCheckCount")
+        val sizeReduction = stats.str("sizeDiff") ?: "0 GB"
+        val tdarrScore = stats.str("tdarrScore") ?: "N/A"
+
+        val nodes = nodesObj?.entries?.mapNotNull { (key, value) ->
+            val nodeObj = value as? JsonObject ?: return@mapNotNull null
+            TdarrNode(
+                id = key,
+                name = nodeObj.str("nodeName") ?: key,
+                workers = nodeObj.int("workers"),
+                online = nodeObj.str("online")?.toBooleanStrictOrNull() ?: true
+            )
+        } ?: emptyList()
+
+        TdarrDashboardData(
+            totalFiles = totalFiles,
+            totalTranscodeCount = totalTranscodeCount,
+            totalHealthCheckCount = totalHealthCheckCount,
+            sizeReduction = sizeReduction,
+            nodes = nodes,
+            tdarrScore = tdarrScore
+        )
+    }
+
+    private fun cleanUrl(raw: String): String {
+        var clean = raw.trim()
+        if (!clean.startsWith("http://") && !clean.startsWith("https://")) {
+            clean = "https://$clean"
+        }
+        return clean.replace(Regex("/+$"), "")
+    }
+}
+
+private fun JsonObject.str(key: String): String? {
+    val element = this[key] ?: return null
+    val primitive = element as? JsonPrimitive ?: return null
+    val content = primitive.content
+    return if (content.equals("null", ignoreCase = true)) null else content
+}
+
+private fun JsonObject.int(key: String): Int {
+    val element = this[key] ?: return 0
+    val primitive = element as? JsonPrimitive ?: return 0
+    return primitive.content.toIntOrNull() ?: primitive.content.toDoubleOrNull()?.toInt() ?: 0
+}

--- a/HomelabAndroid/app/src/main/java/com/homelab/app/di/NetworkModule.kt
+++ b/HomelabAndroid/app/src/main/java/com/homelab/app/di/NetworkModule.kt
@@ -240,4 +240,50 @@ object NetworkModule {
     fun providePlexApi(retrofit: Retrofit): com.homelab.app.data.remote.api.PlexApi {
         return retrofit.create(com.homelab.app.data.remote.api.PlexApi::class.java)
     }
+
+    @Provides
+    @Singleton
+    fun provideJellyfinApi(retrofit: Retrofit): com.homelab.app.data.remote.api.JellyfinApi {
+        return retrofit.create(com.homelab.app.data.remote.api.JellyfinApi::class.java)
+    }
+
+    @Provides
+    @Singleton
+    fun provideImmichApi(retrofit: Retrofit): com.homelab.app.data.remote.api.ImmichApi {
+        return retrofit.create(com.homelab.app.data.remote.api.ImmichApi::class.java)
+    }
+
+    @Provides
+    @Singleton
+    fun provideGrafanaApi(retrofit: Retrofit): com.homelab.app.data.remote.api.GrafanaApi {
+        return retrofit.create(com.homelab.app.data.remote.api.GrafanaApi::class.java)
+    }
+
+    @Provides
+    @Singleton
+    fun provideSABnzbdApi(retrofit: Retrofit): com.homelab.app.data.remote.api.SABnzbdApi {
+        return retrofit.create(com.homelab.app.data.remote.api.SABnzbdApi::class.java)
+    }
+
+    @Provides
+    @Singleton
+    fun provideProxmoxApi(
+        @Named("insecure") retrofit: Retrofit
+    ): com.homelab.app.data.remote.api.ProxmoxApi {
+        return retrofit.create(com.homelab.app.data.remote.api.ProxmoxApi::class.java)
+    }
+
+    @Provides
+    @Singleton
+    fun providePBSApi(
+        @Named("insecure") retrofit: Retrofit
+    ): com.homelab.app.data.remote.api.PBSApi {
+        return retrofit.create(com.homelab.app.data.remote.api.PBSApi::class.java)
+    }
+
+    @Provides
+    @Singleton
+    fun provideTdarrApi(retrofit: Retrofit): com.homelab.app.data.remote.api.TdarrApi {
+        return retrofit.create(com.homelab.app.data.remote.api.TdarrApi::class.java)
+    }
 }

--- a/HomelabAndroid/app/src/main/java/com/homelab/app/ui/grafana/GrafanaDashboardScreen.kt
+++ b/HomelabAndroid/app/src/main/java/com/homelab/app/ui/grafana/GrafanaDashboardScreen.kt
@@ -1,0 +1,198 @@
+package com.homelab.app.ui.grafana
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.homelab.app.data.repository.GrafanaAlert
+import com.homelab.app.data.repository.GrafanaDashboardData
+import com.homelab.app.data.repository.GrafanaDashboardItem
+import com.homelab.app.ui.components.ServiceIcon
+import com.homelab.app.ui.theme.primaryColor
+import com.homelab.app.util.ServiceType
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@Composable
+fun GrafanaDashboardScreen(
+    onNavigateBack: () -> Unit,
+    onNavigateToInstance: (String) -> Unit,
+    viewModel: GrafanaViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val accent = ServiceType.GRAFANA.primaryColor
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Grafana") },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                actions = {
+                    IconButton(onClick = { viewModel.refresh() }) {
+                        Icon(Icons.Default.Refresh, contentDescription = "Refresh", tint = accent)
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = MaterialTheme.colorScheme.background)
+            )
+        }
+    ) { padding ->
+        when (val state = uiState) {
+            GrafanaUiState.Loading -> {
+                Box(modifier = Modifier.fillMaxSize().padding(padding), contentAlignment = Alignment.Center) {
+                    CircularProgressIndicator(color = accent)
+                }
+            }
+            is GrafanaUiState.Error -> {
+                Box(modifier = Modifier.fillMaxSize().padding(padding).padding(24.dp), contentAlignment = Alignment.Center) {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        Text(state.message, style = MaterialTheme.typography.bodyLarge, color = MaterialTheme.colorScheme.error)
+                        Spacer(modifier = Modifier.height(12.dp))
+                        TextButton(onClick = { viewModel.refresh() }) { Text("Retry") }
+                    }
+                }
+            }
+            is GrafanaUiState.Success -> {
+                GrafanaContent(padding = padding, data = state.data, accent = accent)
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun GrafanaContent(padding: PaddingValues, data: GrafanaDashboardData, accent: Color) {
+    LazyColumn(
+        modifier = Modifier.fillMaxSize().padding(padding),
+        contentPadding = PaddingValues(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        item {
+            Surface(shape = RoundedCornerShape(24.dp), color = MaterialTheme.colorScheme.surfaceContainerLow) {
+                Column(modifier = Modifier.fillMaxWidth().padding(20.dp), verticalArrangement = Arrangement.spacedBy(14.dp)) {
+                    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(14.dp)) {
+                        ServiceIcon(type = ServiceType.GRAFANA, size = 64.dp, iconSize = 36.dp, cornerRadius = 18.dp)
+                        Column {
+                            Text("Grafana", style = MaterialTheme.typography.headlineSmall, fontWeight = FontWeight.Bold)
+                            Text("v${data.version}", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                        }
+                    }
+
+                    FlowRow(horizontalArrangement = Arrangement.spacedBy(10.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                        MetricPill("Dashboards", data.dashboardCount.toString(), accent)
+                        MetricPill("Alerts", data.alertCount.toString(), accent)
+                        if (data.firingAlerts > 0) {
+                            MetricPill("Firing", data.firingAlerts.toString(), MaterialTheme.colorScheme.error)
+                        }
+                    }
+                }
+            }
+        }
+
+        if (data.dashboards.isNotEmpty()) {
+            item {
+                Text("Dashboards", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+            }
+            items(data.dashboards.take(15), key = { "dash-${it.uid}" }) { dashboard ->
+                DashboardCard(dashboard = dashboard, accent = accent)
+            }
+        }
+
+        if (data.alerts.isNotEmpty()) {
+            item {
+                Text("Alerts", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+            }
+            items(data.alerts.take(10), key = { "alert-${it.name}" }) { alert ->
+                AlertCard(alert = alert, accent = accent)
+            }
+        }
+    }
+}
+
+@Composable
+private fun MetricPill(label: String, value: String, accent: Color) {
+    Surface(shape = RoundedCornerShape(16.dp), color = accent.copy(alpha = 0.12f)) {
+        Column(modifier = Modifier.padding(horizontal = 14.dp, vertical = 10.dp)) {
+            Text(value, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold, color = accent)
+            Text(label, style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        }
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun DashboardCard(dashboard: GrafanaDashboardItem, accent: Color) {
+    Surface(shape = RoundedCornerShape(16.dp), color = MaterialTheme.colorScheme.surfaceContainerLow) {
+        Column(modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 12.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            Text(dashboard.title, style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold, maxLines = 1, overflow = TextOverflow.Ellipsis)
+            if (dashboard.tags.isNotEmpty()) {
+                FlowRow(horizontalArrangement = Arrangement.spacedBy(6.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                    dashboard.tags.take(5).forEach { tag ->
+                        Surface(shape = RoundedCornerShape(10.dp), color = accent.copy(alpha = 0.10f)) {
+                            Text(tag, modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp), style = MaterialTheme.typography.labelSmall, color = accent)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun AlertCard(alert: GrafanaAlert, accent: Color) {
+    val stateColor = when {
+        alert.state.equals("active", ignoreCase = true) || alert.state.equals("firing", ignoreCase = true) -> MaterialTheme.colorScheme.error
+        alert.state.equals("resolved", ignoreCase = true) || alert.state.equals("normal", ignoreCase = true) -> Color(0xFF16A34A)
+        else -> MaterialTheme.colorScheme.onSurfaceVariant
+    }
+    Surface(shape = RoundedCornerShape(16.dp), color = MaterialTheme.colorScheme.surfaceContainerLow) {
+        Row(modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 12.dp), horizontalArrangement = Arrangement.SpaceBetween, verticalAlignment = Alignment.CenterVertically) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(alert.name, style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                alert.severity?.let {
+                    Text(it, style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
+            }
+            Surface(shape = RoundedCornerShape(10.dp), color = stateColor.copy(alpha = 0.12f)) {
+                Text(alert.state.replaceFirstChar { it.uppercase() }, modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp), style = MaterialTheme.typography.labelSmall, color = stateColor, fontWeight = FontWeight.SemiBold)
+            }
+        }
+    }
+}

--- a/HomelabAndroid/app/src/main/java/com/homelab/app/ui/grafana/GrafanaViewModel.kt
+++ b/HomelabAndroid/app/src/main/java/com/homelab/app/ui/grafana/GrafanaViewModel.kt
@@ -1,0 +1,73 @@
+package com.homelab.app.ui.grafana
+
+import android.content.Context
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.homelab.app.data.repository.GrafanaDashboardData
+import com.homelab.app.data.repository.GrafanaRepository
+import com.homelab.app.data.repository.ServicesRepository
+import com.homelab.app.domain.model.ServiceInstance
+import com.homelab.app.util.ErrorHandler
+import com.homelab.app.util.ServiceType
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+sealed interface GrafanaUiState {
+    data object Loading : GrafanaUiState
+    data class Success(val data: GrafanaDashboardData) : GrafanaUiState
+    data class Error(val message: String) : GrafanaUiState
+}
+
+@HiltViewModel
+class GrafanaViewModel @Inject constructor(
+    private val repository: GrafanaRepository,
+    private val servicesRepository: ServicesRepository,
+    savedStateHandle: SavedStateHandle,
+    @param:ApplicationContext private val context: Context
+) : ViewModel() {
+
+    val instanceId: String = checkNotNull(savedStateHandle["instanceId"])
+
+    private val _uiState = MutableStateFlow<GrafanaUiState>(GrafanaUiState.Loading)
+    val uiState: StateFlow<GrafanaUiState> = _uiState
+
+    val instances: StateFlow<List<ServiceInstance>> = servicesRepository.instancesByType
+        .map { it[ServiceType.GRAFANA].orEmpty() }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
+    private var refreshJob: Job? = null
+
+    init {
+        refresh()
+    }
+
+    fun refresh() {
+        refreshJob?.cancel()
+        refreshJob = viewModelScope.launch {
+            _uiState.value = GrafanaUiState.Loading
+            try {
+                val data = repository.getDashboard(instanceId)
+                _uiState.value = GrafanaUiState.Success(data)
+            } catch (error: Exception) {
+                if (error is CancellationException) throw error
+                _uiState.value = GrafanaUiState.Error(ErrorHandler.getMessage(context, error))
+            }
+        }
+    }
+
+    fun setPreferredInstance(newInstanceId: String) {
+        viewModelScope.launch {
+            servicesRepository.setPreferredInstance(ServiceType.GRAFANA, newInstanceId)
+        }
+    }
+}

--- a/HomelabAndroid/app/src/main/java/com/homelab/app/ui/immich/ImmichDashboardScreen.kt
+++ b/HomelabAndroid/app/src/main/java/com/homelab/app/ui/immich/ImmichDashboardScreen.kt
@@ -1,0 +1,166 @@
+package com.homelab.app.ui.immich
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.homelab.app.data.repository.ImmichDashboardData
+import com.homelab.app.ui.components.ServiceIcon
+import com.homelab.app.ui.theme.primaryColor
+import com.homelab.app.util.ServiceType
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@Composable
+fun ImmichDashboardScreen(
+    onNavigateBack: () -> Unit,
+    onNavigateToInstance: (String) -> Unit,
+    viewModel: ImmichViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val accent = ServiceType.IMMICH.primaryColor
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Immich") },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                actions = {
+                    IconButton(onClick = { viewModel.refresh() }) {
+                        Icon(Icons.Default.Refresh, contentDescription = "Refresh", tint = accent)
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = MaterialTheme.colorScheme.background)
+            )
+        }
+    ) { padding ->
+        when (val state = uiState) {
+            ImmichUiState.Loading -> {
+                Box(
+                    modifier = Modifier.fillMaxSize().padding(padding),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator(color = accent)
+                }
+            }
+            is ImmichUiState.Error -> {
+                Box(
+                    modifier = Modifier.fillMaxSize().padding(padding).padding(24.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        Text(state.message, style = MaterialTheme.typography.bodyLarge, color = MaterialTheme.colorScheme.error)
+                        Spacer(modifier = Modifier.height(12.dp))
+                        TextButton(onClick = { viewModel.refresh() }) { Text("Retry") }
+                    }
+                }
+            }
+            is ImmichUiState.Success -> {
+                ImmichContent(padding = padding, data = state.data, accent = accent)
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun ImmichContent(padding: PaddingValues, data: ImmichDashboardData, accent: Color) {
+    LazyColumn(
+        modifier = Modifier.fillMaxSize().padding(padding),
+        contentPadding = PaddingValues(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        item {
+            Surface(
+                shape = RoundedCornerShape(24.dp),
+                color = MaterialTheme.colorScheme.surfaceContainerLow
+            ) {
+                Column(
+                    modifier = Modifier.fillMaxWidth().padding(20.dp),
+                    verticalArrangement = Arrangement.spacedBy(14.dp)
+                ) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(14.dp)
+                    ) {
+                        ServiceIcon(type = ServiceType.IMMICH, size = 64.dp, iconSize = 36.dp, cornerRadius = 18.dp)
+                        Column {
+                            Text("Immich", style = MaterialTheme.typography.headlineSmall, fontWeight = FontWeight.Bold)
+                            Text("v${data.version}", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                        }
+                    }
+
+                    FlowRow(
+                        horizontalArrangement = Arrangement.spacedBy(10.dp),
+                        verticalArrangement = Arrangement.spacedBy(10.dp)
+                    ) {
+                        MetricPill("Photos", data.totalPhotos.toString(), accent)
+                        MetricPill("Videos", data.totalVideos.toString(), accent)
+                        if (data.totalUsage > 0) {
+                            MetricPill("Storage", formatBytes(data.totalUsage), accent)
+                        }
+                        if (data.totalUsers > 0) {
+                            MetricPill("Users", data.totalUsers.toString(), accent)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun MetricPill(label: String, value: String, accent: Color) {
+    Surface(shape = RoundedCornerShape(16.dp), color = accent.copy(alpha = 0.12f)) {
+        Column(modifier = Modifier.padding(horizontal = 14.dp, vertical = 10.dp)) {
+            Text(value, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold, color = accent)
+            Text(label, style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        }
+    }
+}
+
+private fun formatBytes(bytes: Long): String {
+    val gb = bytes / (1024.0 * 1024.0 * 1024.0)
+    val tb = gb / 1024.0
+    return if (tb >= 1.0) {
+        "%.1f TB".format(tb)
+    } else {
+        "%.1f GB".format(gb)
+    }
+}

--- a/HomelabAndroid/app/src/main/java/com/homelab/app/ui/immich/ImmichViewModel.kt
+++ b/HomelabAndroid/app/src/main/java/com/homelab/app/ui/immich/ImmichViewModel.kt
@@ -1,0 +1,73 @@
+package com.homelab.app.ui.immich
+
+import android.content.Context
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.homelab.app.data.repository.ImmichDashboardData
+import com.homelab.app.data.repository.ImmichRepository
+import com.homelab.app.data.repository.ServicesRepository
+import com.homelab.app.domain.model.ServiceInstance
+import com.homelab.app.util.ErrorHandler
+import com.homelab.app.util.ServiceType
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+sealed interface ImmichUiState {
+    data object Loading : ImmichUiState
+    data class Success(val data: ImmichDashboardData) : ImmichUiState
+    data class Error(val message: String) : ImmichUiState
+}
+
+@HiltViewModel
+class ImmichViewModel @Inject constructor(
+    private val repository: ImmichRepository,
+    private val servicesRepository: ServicesRepository,
+    savedStateHandle: SavedStateHandle,
+    @param:ApplicationContext private val context: Context
+) : ViewModel() {
+
+    val instanceId: String = checkNotNull(savedStateHandle["instanceId"])
+
+    private val _uiState = MutableStateFlow<ImmichUiState>(ImmichUiState.Loading)
+    val uiState: StateFlow<ImmichUiState> = _uiState
+
+    val instances: StateFlow<List<ServiceInstance>> = servicesRepository.instancesByType
+        .map { it[ServiceType.IMMICH].orEmpty() }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
+    private var refreshJob: Job? = null
+
+    init {
+        refresh()
+    }
+
+    fun refresh() {
+        refreshJob?.cancel()
+        refreshJob = viewModelScope.launch {
+            _uiState.value = ImmichUiState.Loading
+            try {
+                val data = repository.getDashboard(instanceId)
+                _uiState.value = ImmichUiState.Success(data)
+            } catch (error: Exception) {
+                if (error is CancellationException) throw error
+                _uiState.value = ImmichUiState.Error(ErrorHandler.getMessage(context, error))
+            }
+        }
+    }
+
+    fun setPreferredInstance(newInstanceId: String) {
+        viewModelScope.launch {
+            servicesRepository.setPreferredInstance(ServiceType.IMMICH, newInstanceId)
+        }
+    }
+}

--- a/HomelabAndroid/app/src/main/java/com/homelab/app/ui/jellyfin/JellyfinDashboardScreen.kt
+++ b/HomelabAndroid/app/src/main/java/com/homelab/app/ui/jellyfin/JellyfinDashboardScreen.kt
@@ -1,0 +1,228 @@
+package com.homelab.app.ui.jellyfin
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.homelab.app.data.repository.JellyfinDashboardData
+import com.homelab.app.data.repository.JellyfinSession
+import com.homelab.app.ui.components.ServiceIcon
+import com.homelab.app.ui.theme.primaryColor
+import com.homelab.app.util.ServiceType
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@Composable
+fun JellyfinDashboardScreen(
+    onNavigateBack: () -> Unit,
+    onNavigateToInstance: (String) -> Unit,
+    viewModel: JellyfinViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val accent = ServiceType.JELLYFIN.primaryColor
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Jellyfin") },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                actions = {
+                    IconButton(onClick = { viewModel.refresh() }) {
+                        Icon(Icons.Default.Refresh, contentDescription = "Refresh", tint = accent)
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = MaterialTheme.colorScheme.background)
+            )
+        }
+    ) { padding ->
+        when (val state = uiState) {
+            JellyfinUiState.Loading -> {
+                Box(
+                    modifier = Modifier.fillMaxSize().padding(padding),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator(color = accent)
+                }
+            }
+            is JellyfinUiState.Error -> {
+                Box(
+                    modifier = Modifier.fillMaxSize().padding(padding).padding(24.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        Text(
+                            text = state.message,
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = MaterialTheme.colorScheme.error
+                        )
+                        Spacer(modifier = Modifier.height(12.dp))
+                        TextButton(onClick = { viewModel.refresh() }) {
+                            Text("Retry")
+                        }
+                    }
+                }
+            }
+            is JellyfinUiState.Success -> {
+                JellyfinContent(padding = padding, data = state.data, accent = accent)
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun JellyfinContent(
+    padding: PaddingValues,
+    data: JellyfinDashboardData,
+    accent: androidx.compose.ui.graphics.Color
+) {
+    LazyColumn(
+        modifier = Modifier.fillMaxSize().padding(padding),
+        contentPadding = PaddingValues(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        item {
+            Surface(
+                shape = RoundedCornerShape(24.dp),
+                color = MaterialTheme.colorScheme.surfaceContainerLow
+            ) {
+                Column(
+                    modifier = Modifier.fillMaxWidth().padding(20.dp),
+                    verticalArrangement = Arrangement.spacedBy(14.dp)
+                ) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(14.dp)
+                    ) {
+                        ServiceIcon(
+                            type = ServiceType.JELLYFIN,
+                            size = 64.dp,
+                            iconSize = 36.dp,
+                            cornerRadius = 18.dp
+                        )
+                        Column {
+                            Text(
+                                text = data.serverName,
+                                style = MaterialTheme.typography.headlineSmall,
+                                fontWeight = FontWeight.Bold
+                            )
+                            Text(
+                                text = "v${data.version} -- ${data.operatingSystem}",
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    }
+
+                    FlowRow(
+                        horizontalArrangement = Arrangement.spacedBy(10.dp),
+                        verticalArrangement = Arrangement.spacedBy(10.dp)
+                    ) {
+                        MetricPill("Sessions", data.activeSessions.toString(), accent)
+                        MetricPill("Streams", data.activeStreams.toString(), accent)
+                        if (data.totalItems > 0) {
+                            MetricPill("Items", data.totalItems.toString(), accent)
+                        }
+                    }
+                }
+            }
+        }
+
+        if (data.sessions.isNotEmpty()) {
+            item {
+                Text("Active Sessions", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+            }
+            items(data.sessions, key = { it.id }) { session ->
+                SessionCard(session = session, accent = accent)
+            }
+        }
+    }
+}
+
+@Composable
+private fun MetricPill(label: String, value: String, accent: androidx.compose.ui.graphics.Color) {
+    Surface(
+        shape = RoundedCornerShape(16.dp),
+        color = accent.copy(alpha = 0.12f)
+    ) {
+        Column(modifier = Modifier.padding(horizontal = 14.dp, vertical = 10.dp)) {
+            Text(value, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold, color = accent)
+            Text(label, style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        }
+    }
+}
+
+@Composable
+private fun SessionCard(session: JellyfinSession, accent: androidx.compose.ui.graphics.Color) {
+    Surface(
+        shape = RoundedCornerShape(16.dp),
+        color = MaterialTheme.colorScheme.surfaceContainerLow
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 12.dp),
+            verticalArrangement = Arrangement.spacedBy(4.dp)
+        ) {
+            Text(
+                text = session.userName,
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.SemiBold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+            Text(
+                text = "${session.client} -- ${session.deviceName}",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+            if (session.nowPlayingTitle != null) {
+                Text(
+                    text = "Playing: ${session.nowPlayingTitle}",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = accent,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+        }
+    }
+}

--- a/HomelabAndroid/app/src/main/java/com/homelab/app/ui/jellyfin/JellyfinViewModel.kt
+++ b/HomelabAndroid/app/src/main/java/com/homelab/app/ui/jellyfin/JellyfinViewModel.kt
@@ -1,0 +1,73 @@
+package com.homelab.app.ui.jellyfin
+
+import android.content.Context
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.homelab.app.data.repository.JellyfinDashboardData
+import com.homelab.app.data.repository.JellyfinRepository
+import com.homelab.app.data.repository.ServicesRepository
+import com.homelab.app.domain.model.ServiceInstance
+import com.homelab.app.util.ErrorHandler
+import com.homelab.app.util.ServiceType
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+sealed interface JellyfinUiState {
+    data object Loading : JellyfinUiState
+    data class Success(val data: JellyfinDashboardData) : JellyfinUiState
+    data class Error(val message: String) : JellyfinUiState
+}
+
+@HiltViewModel
+class JellyfinViewModel @Inject constructor(
+    private val repository: JellyfinRepository,
+    private val servicesRepository: ServicesRepository,
+    savedStateHandle: SavedStateHandle,
+    @param:ApplicationContext private val context: Context
+) : ViewModel() {
+
+    val instanceId: String = checkNotNull(savedStateHandle["instanceId"])
+
+    private val _uiState = MutableStateFlow<JellyfinUiState>(JellyfinUiState.Loading)
+    val uiState: StateFlow<JellyfinUiState> = _uiState
+
+    val instances: StateFlow<List<ServiceInstance>> = servicesRepository.instancesByType
+        .map { it[ServiceType.JELLYFIN].orEmpty() }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
+    private var refreshJob: Job? = null
+
+    init {
+        refresh()
+    }
+
+    fun refresh() {
+        refreshJob?.cancel()
+        refreshJob = viewModelScope.launch {
+            _uiState.value = JellyfinUiState.Loading
+            try {
+                val data = repository.getDashboard(instanceId)
+                _uiState.value = JellyfinUiState.Success(data)
+            } catch (error: Exception) {
+                if (error is CancellationException) throw error
+                _uiState.value = JellyfinUiState.Error(ErrorHandler.getMessage(context, error))
+            }
+        }
+    }
+
+    fun setPreferredInstance(newInstanceId: String) {
+        viewModelScope.launch {
+            servicesRepository.setPreferredInstance(ServiceType.JELLYFIN, newInstanceId)
+        }
+    }
+}

--- a/HomelabAndroid/app/src/main/java/com/homelab/app/ui/login/ServiceLoginScreen.kt
+++ b/HomelabAndroid/app/src/main/java/com/homelab/app/ui/login/ServiceLoginScreen.kt
@@ -205,6 +205,13 @@ fun ServiceLoginScreen(
                 ServiceType.BAZARR -> stringResource(R.string.login_hint_bazarr)
                 ServiceType.GLUETUN -> stringResource(R.string.login_hint_gluetun)
                 ServiceType.FLARESOLVERR -> stringResource(R.string.login_hint_flaresolverr)
+                ServiceType.JELLYFIN -> stringResource(R.string.login_hint_jellyfin)
+                ServiceType.IMMICH -> stringResource(R.string.login_hint_immich)
+                ServiceType.GRAFANA -> stringResource(R.string.login_hint_grafana)
+                ServiceType.SABNZBD -> stringResource(R.string.login_hint_sabnzbd)
+                ServiceType.PROXMOX -> stringResource(R.string.login_hint_proxmox)
+                ServiceType.PROXMOX_BACKUP_SERVER -> stringResource(R.string.login_hint_pbs)
+                ServiceType.TDARR -> stringResource(R.string.login_hint_tdarr)
                 else -> null
             }
 
@@ -419,7 +426,13 @@ fun ServiceLoginScreen(
                 serviceType == ServiceType.LIDARR ||
                 serviceType == ServiceType.JELLYSEERR ||
                 serviceType == ServiceType.PROWLARR ||
-                serviceType == ServiceType.BAZARR
+                serviceType == ServiceType.BAZARR ||
+                serviceType == ServiceType.JELLYFIN ||
+                serviceType == ServiceType.IMMICH ||
+                serviceType == ServiceType.GRAFANA ||
+                serviceType == ServiceType.SABNZBD ||
+                serviceType == ServiceType.PROXMOX ||
+                serviceType == ServiceType.PROXMOX_BACKUP_SERVER
             ) {
                 SecretField(
                     value = apiKey,
@@ -430,7 +443,8 @@ fun ServiceLoginScreen(
                 )
             } else if (
                 serviceType == ServiceType.GLUETUN ||
-                serviceType == ServiceType.FLARESOLVERR
+                serviceType == ServiceType.FLARESOLVERR ||
+                serviceType == ServiceType.TDARR
             ) {
                 SecretField(
                     value = apiKey,

--- a/HomelabAndroid/app/src/main/java/com/homelab/app/ui/login/ServiceLoginViewModel.kt
+++ b/HomelabAndroid/app/src/main/java/com/homelab/app/ui/login/ServiceLoginViewModel.kt
@@ -13,14 +13,21 @@ import com.homelab.app.data.repository.HealthchecksRepository
 import com.homelab.app.data.repository.JellystatRepository
 import com.homelab.app.data.repository.MediaArrRepository
 import com.homelab.app.data.repository.AdGuardHomeRepository
+import com.homelab.app.data.repository.GrafanaRepository
+import com.homelab.app.data.repository.ImmichRepository
+import com.homelab.app.data.repository.JellyfinRepository
 import com.homelab.app.data.repository.NginxProxyManagerRepository
+import com.homelab.app.data.repository.PBSRepository
 import com.homelab.app.data.repository.PatchmonRepository
 import com.homelab.app.data.repository.PangolinRepository
 import com.homelab.app.data.repository.PiholeRepository
 import com.homelab.app.data.repository.PlexRepository
 import com.homelab.app.data.repository.PortainerRepository
+import com.homelab.app.data.repository.ProxmoxRepository
+import com.homelab.app.data.repository.SABnzbdRepository
 import com.homelab.app.data.repository.ServiceInstancesRepository
 import com.homelab.app.data.repository.ServicesRepository
+import com.homelab.app.data.repository.TdarrRepository
 import com.homelab.app.data.repository.TechnitiumRepository
 import com.homelab.app.domain.model.PiHoleAuthMode
 import com.homelab.app.domain.model.ServiceInstance
@@ -54,7 +61,14 @@ class ServiceLoginViewModel @Inject constructor(
     private val patchmonRepository: PatchmonRepository,
     private val pangolinRepository: PangolinRepository,
     private val plexRepository: PlexRepository,
-    private val mediaArrRepository: MediaArrRepository
+    private val mediaArrRepository: MediaArrRepository,
+    private val jellyfinRepository: JellyfinRepository,
+    private val immichRepository: ImmichRepository,
+    private val grafanaRepository: GrafanaRepository,
+    private val sabnzbdRepository: SABnzbdRepository,
+    private val proxmoxRepository: ProxmoxRepository,
+    private val pbsRepository: PBSRepository,
+    private val tdarrRepository: TdarrRepository
 ) : ViewModel() {
 
     private val existingInstanceId: String? = savedStateHandle["instanceId"]
@@ -420,6 +434,89 @@ class ServiceLoginViewModel @Inject constructor(
                                 apiKey = trimmedApiKey,
                                 fallbackUrl = cleanFallbackUrl
                             )
+                            ServiceInstance(
+                                id = instanceId,
+                                type = serviceType,
+                                label = normalizedLabel,
+                                url = cleanUrl,
+                                apiKey = trimmedApiKey.ifBlank { null },
+                                fallbackUrl = cleanFallbackUrl
+                            )
+                        }
+                        ServiceType.JELLYFIN -> {
+                            require(trimmedApiKey.isNotBlank()) { context.getString(R.string.login_error_api_key_required) }
+                            jellyfinRepository.authenticate(cleanUrl, trimmedApiKey)
+                            ServiceInstance(
+                                id = instanceId,
+                                type = serviceType,
+                                label = normalizedLabel,
+                                url = cleanUrl,
+                                apiKey = trimmedApiKey,
+                                fallbackUrl = cleanFallbackUrl
+                            )
+                        }
+                        ServiceType.IMMICH -> {
+                            require(trimmedApiKey.isNotBlank()) { context.getString(R.string.login_error_api_key_required) }
+                            immichRepository.authenticate(cleanUrl, trimmedApiKey)
+                            ServiceInstance(
+                                id = instanceId,
+                                type = serviceType,
+                                label = normalizedLabel,
+                                url = cleanUrl,
+                                apiKey = trimmedApiKey,
+                                fallbackUrl = cleanFallbackUrl
+                            )
+                        }
+                        ServiceType.GRAFANA -> {
+                            require(trimmedApiKey.isNotBlank()) { context.getString(R.string.login_error_api_key_required) }
+                            grafanaRepository.authenticate(cleanUrl, trimmedApiKey)
+                            ServiceInstance(
+                                id = instanceId,
+                                type = serviceType,
+                                label = normalizedLabel,
+                                url = cleanUrl,
+                                apiKey = trimmedApiKey,
+                                fallbackUrl = cleanFallbackUrl
+                            )
+                        }
+                        ServiceType.SABNZBD -> {
+                            require(trimmedApiKey.isNotBlank()) { context.getString(R.string.login_error_api_key_required) }
+                            sabnzbdRepository.authenticate(cleanUrl, trimmedApiKey)
+                            ServiceInstance(
+                                id = instanceId,
+                                type = serviceType,
+                                label = normalizedLabel,
+                                url = cleanUrl,
+                                apiKey = trimmedApiKey,
+                                fallbackUrl = cleanFallbackUrl
+                            )
+                        }
+                        ServiceType.PROXMOX -> {
+                            require(trimmedApiKey.isNotBlank()) { context.getString(R.string.login_error_api_key_required) }
+                            proxmoxRepository.authenticate(cleanUrl, trimmedApiKey)
+                            ServiceInstance(
+                                id = instanceId,
+                                type = serviceType,
+                                label = normalizedLabel,
+                                url = cleanUrl,
+                                apiKey = trimmedApiKey,
+                                fallbackUrl = cleanFallbackUrl
+                            )
+                        }
+                        ServiceType.PROXMOX_BACKUP_SERVER -> {
+                            require(trimmedApiKey.isNotBlank()) { context.getString(R.string.login_error_api_key_required) }
+                            pbsRepository.authenticate(cleanUrl, trimmedApiKey)
+                            ServiceInstance(
+                                id = instanceId,
+                                type = serviceType,
+                                label = normalizedLabel,
+                                url = cleanUrl,
+                                apiKey = trimmedApiKey,
+                                fallbackUrl = cleanFallbackUrl
+                            )
+                        }
+                        ServiceType.TDARR -> {
+                            tdarrRepository.authenticate(cleanUrl, trimmedApiKey)
                             ServiceInstance(
                                 id = instanceId,
                                 type = serviceType,

--- a/HomelabAndroid/app/src/main/java/com/homelab/app/ui/navigation/AppNavigation.kt
+++ b/HomelabAndroid/app/src/main/java/com/homelab/app/ui/navigation/AppNavigation.kt
@@ -91,6 +91,13 @@ private fun dashboardRoute(type: ServiceType, instanceId: String): String {
         ServiceType.HEALTHCHECKS -> "healthchecks/$instanceId/dashboard"
         ServiceType.PATCHMON -> "patchmon/$instanceId/dashboard"
         ServiceType.PLEX -> "plex/$instanceId/dashboard"
+        ServiceType.JELLYFIN -> "jellyfin/$instanceId/dashboard"
+        ServiceType.IMMICH -> "immich/$instanceId/dashboard"
+        ServiceType.GRAFANA -> "grafana/$instanceId/dashboard"
+        ServiceType.SABNZBD -> "sabnzbd/$instanceId/dashboard"
+        ServiceType.PROXMOX -> "proxmox/$instanceId/dashboard"
+        ServiceType.PROXMOX_BACKUP_SERVER -> "pbs/$instanceId/dashboard"
+        ServiceType.TDARR -> "tdarr/$instanceId/dashboard"
         ServiceType.RADARR,
         ServiceType.SONARR,
         ServiceType.LIDARR,
@@ -845,6 +852,125 @@ fun AppNavigation() {
                         if (newInstanceId != instanceId) {
                             navController.navigate(dashboardRoute(ServiceType.PLEX, newInstanceId)) {
                                 popUpTo("plex/$instanceId/dashboard") { inclusive = true }
+                            }
+                        }
+                    }
+                )
+            }
+
+            composable(
+                route = "jellyfin/{instanceId}/dashboard",
+                arguments = listOf(androidx.navigation.navArgument("instanceId") { type = NavType.StringType })
+            ) { backStackEntry ->
+                val instanceId = backStackEntry.arguments?.getString("instanceId") ?: return@composable
+                com.homelab.app.ui.jellyfin.JellyfinDashboardScreen(
+                    onNavigateBack = { navController.popBackStack() },
+                    onNavigateToInstance = { newInstanceId ->
+                        if (newInstanceId != instanceId) {
+                            navController.navigate(dashboardRoute(ServiceType.JELLYFIN, newInstanceId)) {
+                                popUpTo("jellyfin/$instanceId/dashboard") { inclusive = true }
+                            }
+                        }
+                    }
+                )
+            }
+
+            composable(
+                route = "immich/{instanceId}/dashboard",
+                arguments = listOf(androidx.navigation.navArgument("instanceId") { type = NavType.StringType })
+            ) { backStackEntry ->
+                val instanceId = backStackEntry.arguments?.getString("instanceId") ?: return@composable
+                com.homelab.app.ui.immich.ImmichDashboardScreen(
+                    onNavigateBack = { navController.popBackStack() },
+                    onNavigateToInstance = { newInstanceId ->
+                        if (newInstanceId != instanceId) {
+                            navController.navigate(dashboardRoute(ServiceType.IMMICH, newInstanceId)) {
+                                popUpTo("immich/$instanceId/dashboard") { inclusive = true }
+                            }
+                        }
+                    }
+                )
+            }
+
+            composable(
+                route = "grafana/{instanceId}/dashboard",
+                arguments = listOf(androidx.navigation.navArgument("instanceId") { type = NavType.StringType })
+            ) { backStackEntry ->
+                val instanceId = backStackEntry.arguments?.getString("instanceId") ?: return@composable
+                com.homelab.app.ui.grafana.GrafanaDashboardScreen(
+                    onNavigateBack = { navController.popBackStack() },
+                    onNavigateToInstance = { newInstanceId ->
+                        if (newInstanceId != instanceId) {
+                            navController.navigate(dashboardRoute(ServiceType.GRAFANA, newInstanceId)) {
+                                popUpTo("grafana/$instanceId/dashboard") { inclusive = true }
+                            }
+                        }
+                    }
+                )
+            }
+
+            composable(
+                route = "sabnzbd/{instanceId}/dashboard",
+                arguments = listOf(androidx.navigation.navArgument("instanceId") { type = NavType.StringType })
+            ) { backStackEntry ->
+                val instanceId = backStackEntry.arguments?.getString("instanceId") ?: return@composable
+                com.homelab.app.ui.sabnzbd.SABnzbdDashboardScreen(
+                    onNavigateBack = { navController.popBackStack() },
+                    onNavigateToInstance = { newInstanceId ->
+                        if (newInstanceId != instanceId) {
+                            navController.navigate(dashboardRoute(ServiceType.SABNZBD, newInstanceId)) {
+                                popUpTo("sabnzbd/$instanceId/dashboard") { inclusive = true }
+                            }
+                        }
+                    }
+                )
+            }
+
+            composable(
+                route = "proxmox/{instanceId}/dashboard",
+                arguments = listOf(androidx.navigation.navArgument("instanceId") { type = NavType.StringType })
+            ) { backStackEntry ->
+                val instanceId = backStackEntry.arguments?.getString("instanceId") ?: return@composable
+                com.homelab.app.ui.proxmox.ProxmoxDashboardScreen(
+                    onNavigateBack = { navController.popBackStack() },
+                    onNavigateToInstance = { newInstanceId ->
+                        if (newInstanceId != instanceId) {
+                            navController.navigate(dashboardRoute(ServiceType.PROXMOX, newInstanceId)) {
+                                popUpTo("proxmox/$instanceId/dashboard") { inclusive = true }
+                            }
+                        }
+                    }
+                )
+            }
+
+            composable(
+                route = "pbs/{instanceId}/dashboard",
+                arguments = listOf(androidx.navigation.navArgument("instanceId") { type = NavType.StringType })
+            ) { backStackEntry ->
+                val instanceId = backStackEntry.arguments?.getString("instanceId") ?: return@composable
+                com.homelab.app.ui.pbs.PBSDashboardScreen(
+                    onNavigateBack = { navController.popBackStack() },
+                    onNavigateToInstance = { newInstanceId ->
+                        if (newInstanceId != instanceId) {
+                            navController.navigate(dashboardRoute(ServiceType.PROXMOX_BACKUP_SERVER, newInstanceId)) {
+                                popUpTo("pbs/$instanceId/dashboard") { inclusive = true }
+                            }
+                        }
+                    }
+                )
+            }
+
+            composable(
+                route = "tdarr/{instanceId}/dashboard",
+                arguments = listOf(androidx.navigation.navArgument("instanceId") { type = NavType.StringType })
+            ) { backStackEntry ->
+                val instanceId = backStackEntry.arguments?.getString("instanceId") ?: return@composable
+                com.homelab.app.ui.tdarr.TdarrDashboardScreen(
+                    onNavigateBack = { navController.popBackStack() },
+                    onNavigateToInstance = { newInstanceId ->
+                        if (newInstanceId != instanceId) {
+                            navController.navigate(dashboardRoute(ServiceType.TDARR, newInstanceId)) {
+                                popUpTo("tdarr/$instanceId/dashboard") { inclusive = true }
                             }
                         }
                     }

--- a/HomelabAndroid/app/src/main/java/com/homelab/app/ui/pbs/PBSDashboardScreen.kt
+++ b/HomelabAndroid/app/src/main/java/com/homelab/app/ui/pbs/PBSDashboardScreen.kt
@@ -1,0 +1,183 @@
+package com.homelab.app.ui.pbs
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.homelab.app.data.repository.PBSDashboardData
+import com.homelab.app.data.repository.PBSDatastoreUsage
+import com.homelab.app.ui.components.ServiceIcon
+import com.homelab.app.ui.theme.primaryColor
+import com.homelab.app.util.ServiceType
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@Composable
+fun PBSDashboardScreen(
+    onNavigateBack: () -> Unit,
+    onNavigateToInstance: (String) -> Unit,
+    viewModel: PBSViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val accent = ServiceType.PROXMOX_BACKUP_SERVER.primaryColor
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Proxmox Backup Server") },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                actions = {
+                    IconButton(onClick = { viewModel.refresh() }) {
+                        Icon(Icons.Default.Refresh, contentDescription = "Refresh", tint = accent)
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = MaterialTheme.colorScheme.background)
+            )
+        }
+    ) { padding ->
+        when (val state = uiState) {
+            PBSUiState.Loading -> {
+                Box(modifier = Modifier.fillMaxSize().padding(padding), contentAlignment = Alignment.Center) {
+                    CircularProgressIndicator(color = accent)
+                }
+            }
+            is PBSUiState.Error -> {
+                Box(modifier = Modifier.fillMaxSize().padding(padding).padding(24.dp), contentAlignment = Alignment.Center) {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        Text(state.message, style = MaterialTheme.typography.bodyLarge, color = MaterialTheme.colorScheme.error)
+                        Spacer(modifier = Modifier.height(12.dp))
+                        TextButton(onClick = { viewModel.refresh() }) { Text("Retry") }
+                    }
+                }
+            }
+            is PBSUiState.Success -> {
+                PBSContent(padding = padding, data = state.data, accent = accent)
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun PBSContent(padding: PaddingValues, data: PBSDashboardData, accent: Color) {
+    LazyColumn(
+        modifier = Modifier.fillMaxSize().padding(padding),
+        contentPadding = PaddingValues(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        item {
+            Surface(shape = RoundedCornerShape(24.dp), color = MaterialTheme.colorScheme.surfaceContainerLow) {
+                Column(modifier = Modifier.fillMaxWidth().padding(20.dp), verticalArrangement = Arrangement.spacedBy(14.dp)) {
+                    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(14.dp)) {
+                        ServiceIcon(type = ServiceType.PROXMOX_BACKUP_SERVER, size = 64.dp, iconSize = 36.dp, cornerRadius = 18.dp)
+                        Column {
+                            Text("Proxmox Backup Server", style = MaterialTheme.typography.headlineSmall, fontWeight = FontWeight.Bold)
+                            Text("${data.datastores.size} datastore(s)", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                        }
+                    }
+
+                    FlowRow(horizontalArrangement = Arrangement.spacedBy(10.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                        MetricPill("Datastores", data.datastores.size.toString(), accent)
+                    }
+                }
+            }
+        }
+
+        if (data.datastoreUsage.isNotEmpty()) {
+            item { Text("Datastore Usage", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold) }
+            items(data.datastoreUsage, key = { "usage-${it.store}" }) { usage ->
+                DatastoreUsageCard(usage = usage, accent = accent)
+            }
+        }
+
+        if (data.datastores.isNotEmpty()) {
+            item { Text("Datastores", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold) }
+            items(data.datastores, key = { "ds-${it.name}" }) { ds ->
+                Surface(shape = RoundedCornerShape(16.dp), color = MaterialTheme.colorScheme.surfaceContainerLow) {
+                    Column(modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 12.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                        Text(ds.name, style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                        ds.path?.let { Text(it, style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant) }
+                        ds.comment?.let { Text(it, style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant) }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun MetricPill(label: String, value: String, accent: Color) {
+    Surface(shape = RoundedCornerShape(16.dp), color = accent.copy(alpha = 0.12f)) {
+        Column(modifier = Modifier.padding(horizontal = 14.dp, vertical = 10.dp)) {
+            Text(value, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold, color = accent)
+            Text(label, style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        }
+    }
+}
+
+@Composable
+private fun DatastoreUsageCard(usage: PBSDatastoreUsage, accent: Color) {
+    val usedPercent = if (usage.total > 0) (usage.used.toDouble() / usage.total * 100).toInt() else 0
+    val usedRatio = if (usage.total > 0) (usage.used.toFloat() / usage.total).coerceIn(0f, 1f) else 0f
+    Surface(shape = RoundedCornerShape(16.dp), color = MaterialTheme.colorScheme.surfaceContainerLow) {
+        Column(modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 12.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Text(usage.store, style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+            LinearProgressIndicator(
+                progress = { usedRatio },
+                modifier = Modifier.fillMaxWidth().height(6.dp),
+                color = if (usedPercent > 90) MaterialTheme.colorScheme.error else accent,
+                trackColor = accent.copy(alpha = 0.12f)
+            )
+            Text(
+                "$usedPercent% used -- ${formatBytes(usage.used)} / ${formatBytes(usage.total)}",
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+private fun formatBytes(bytes: Long): String {
+    val gb = bytes / (1024.0 * 1024.0 * 1024.0)
+    val tb = gb / 1024.0
+    return if (tb >= 1.0) "%.1f TB".format(tb) else "%.1f GB".format(gb)
+}

--- a/HomelabAndroid/app/src/main/java/com/homelab/app/ui/pbs/PBSViewModel.kt
+++ b/HomelabAndroid/app/src/main/java/com/homelab/app/ui/pbs/PBSViewModel.kt
@@ -1,0 +1,73 @@
+package com.homelab.app.ui.pbs
+
+import android.content.Context
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.homelab.app.data.repository.PBSDashboardData
+import com.homelab.app.data.repository.PBSRepository
+import com.homelab.app.data.repository.ServicesRepository
+import com.homelab.app.domain.model.ServiceInstance
+import com.homelab.app.util.ErrorHandler
+import com.homelab.app.util.ServiceType
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+sealed interface PBSUiState {
+    data object Loading : PBSUiState
+    data class Success(val data: PBSDashboardData) : PBSUiState
+    data class Error(val message: String) : PBSUiState
+}
+
+@HiltViewModel
+class PBSViewModel @Inject constructor(
+    private val repository: PBSRepository,
+    private val servicesRepository: ServicesRepository,
+    savedStateHandle: SavedStateHandle,
+    @param:ApplicationContext private val context: Context
+) : ViewModel() {
+
+    val instanceId: String = checkNotNull(savedStateHandle["instanceId"])
+
+    private val _uiState = MutableStateFlow<PBSUiState>(PBSUiState.Loading)
+    val uiState: StateFlow<PBSUiState> = _uiState
+
+    val instances: StateFlow<List<ServiceInstance>> = servicesRepository.instancesByType
+        .map { it[ServiceType.PROXMOX_BACKUP_SERVER].orEmpty() }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
+    private var refreshJob: Job? = null
+
+    init {
+        refresh()
+    }
+
+    fun refresh() {
+        refreshJob?.cancel()
+        refreshJob = viewModelScope.launch {
+            _uiState.value = PBSUiState.Loading
+            try {
+                val data = repository.getDashboard(instanceId)
+                _uiState.value = PBSUiState.Success(data)
+            } catch (error: Exception) {
+                if (error is CancellationException) throw error
+                _uiState.value = PBSUiState.Error(ErrorHandler.getMessage(context, error))
+            }
+        }
+    }
+
+    fun setPreferredInstance(newInstanceId: String) {
+        viewModelScope.launch {
+            servicesRepository.setPreferredInstance(ServiceType.PROXMOX_BACKUP_SERVER, newInstanceId)
+        }
+    }
+}

--- a/HomelabAndroid/app/src/main/java/com/homelab/app/ui/proxmox/ProxmoxDashboardScreen.kt
+++ b/HomelabAndroid/app/src/main/java/com/homelab/app/ui/proxmox/ProxmoxDashboardScreen.kt
@@ -1,0 +1,215 @@
+package com.homelab.app.ui.proxmox
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.homelab.app.data.repository.ProxmoxDashboardData
+import com.homelab.app.data.repository.ProxmoxNode
+import com.homelab.app.data.repository.ProxmoxResource
+import com.homelab.app.ui.components.ServiceIcon
+import com.homelab.app.ui.theme.primaryColor
+import com.homelab.app.util.ServiceType
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@Composable
+fun ProxmoxDashboardScreen(
+    onNavigateBack: () -> Unit,
+    onNavigateToInstance: (String) -> Unit,
+    viewModel: ProxmoxViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val accent = ServiceType.PROXMOX.primaryColor
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Proxmox VE") },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                actions = {
+                    IconButton(onClick = { viewModel.refresh() }) {
+                        Icon(Icons.Default.Refresh, contentDescription = "Refresh", tint = accent)
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = MaterialTheme.colorScheme.background)
+            )
+        }
+    ) { padding ->
+        when (val state = uiState) {
+            ProxmoxUiState.Loading -> {
+                Box(modifier = Modifier.fillMaxSize().padding(padding), contentAlignment = Alignment.Center) {
+                    CircularProgressIndicator(color = accent)
+                }
+            }
+            is ProxmoxUiState.Error -> {
+                Box(modifier = Modifier.fillMaxSize().padding(padding).padding(24.dp), contentAlignment = Alignment.Center) {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        Text(state.message, style = MaterialTheme.typography.bodyLarge, color = MaterialTheme.colorScheme.error)
+                        Spacer(modifier = Modifier.height(12.dp))
+                        TextButton(onClick = { viewModel.refresh() }) { Text("Retry") }
+                    }
+                }
+            }
+            is ProxmoxUiState.Success -> {
+                ProxmoxContent(padding = padding, data = state.data, accent = accent)
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun ProxmoxContent(padding: PaddingValues, data: ProxmoxDashboardData, accent: Color) {
+    LazyColumn(
+        modifier = Modifier.fillMaxSize().padding(padding),
+        contentPadding = PaddingValues(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        item {
+            Surface(shape = RoundedCornerShape(24.dp), color = MaterialTheme.colorScheme.surfaceContainerLow) {
+                Column(modifier = Modifier.fillMaxWidth().padding(20.dp), verticalArrangement = Arrangement.spacedBy(14.dp)) {
+                    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(14.dp)) {
+                        ServiceIcon(type = ServiceType.PROXMOX, size = 64.dp, iconSize = 36.dp, cornerRadius = 18.dp)
+                        Column {
+                            Text("Proxmox VE", style = MaterialTheme.typography.headlineSmall, fontWeight = FontWeight.Bold)
+                            Text("${data.nodes.size} node(s)", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                        }
+                    }
+
+                    FlowRow(horizontalArrangement = Arrangement.spacedBy(10.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                        MetricPill("VMs", "${data.runningVMs}/${data.totalVMs}", accent)
+                        MetricPill("LXCs", "${data.runningContainers}/${data.totalContainers}", accent)
+                        MetricPill("Nodes", data.nodes.size.toString(), accent)
+                    }
+                }
+            }
+        }
+
+        if (data.nodes.isNotEmpty()) {
+            item { Text("Nodes", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold) }
+            items(data.nodes, key = { "node-${it.node}" }) { node ->
+                NodeCard(node = node, accent = accent)
+            }
+        }
+
+        if (data.resources.isNotEmpty()) {
+            item {
+                Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween, verticalAlignment = Alignment.CenterVertically) {
+                    Text("Resources", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+                    Text("${data.resources.count { it.status == "running" }} running", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
+            }
+            items(data.resources.sortedWith(compareByDescending<ProxmoxResource> { it.status == "running" }.thenBy { it.name.lowercase() }), key = { "res-${it.id}" }) { resource ->
+                ResourceCard(resource = resource, accent = accent)
+            }
+        }
+    }
+}
+
+@Composable
+private fun MetricPill(label: String, value: String, accent: Color) {
+    Surface(shape = RoundedCornerShape(16.dp), color = accent.copy(alpha = 0.12f)) {
+        Column(modifier = Modifier.padding(horizontal = 14.dp, vertical = 10.dp)) {
+            Text(value, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold, color = accent)
+            Text(label, style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        }
+    }
+}
+
+@Composable
+private fun NodeCard(node: ProxmoxNode, accent: Color) {
+    val cpuPercent = (node.cpuUsage * 100).toInt()
+    val memPercent = if (node.memoryTotal > 0) ((node.memoryUsed.toDouble() / node.memoryTotal) * 100).toInt() else 0
+    Surface(shape = RoundedCornerShape(16.dp), color = MaterialTheme.colorScheme.surfaceContainerLow) {
+        Column(modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 12.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween, verticalAlignment = Alignment.CenterVertically) {
+                Text(node.node, style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+                Surface(shape = RoundedCornerShape(10.dp), color = if (node.status == "online") accent.copy(alpha = 0.12f) else MaterialTheme.colorScheme.errorContainer) {
+                    Text(
+                        node.status.replaceFirstChar { it.uppercase() },
+                        modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = if (node.status == "online") accent else MaterialTheme.colorScheme.error,
+                        fontWeight = FontWeight.SemiBold
+                    )
+                }
+            }
+            Text("CPU: $cpuPercent%  |  Memory: $memPercent%  |  Uptime: ${formatUptime(node.uptime)}", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            LinearProgressIndicator(
+                progress = { node.cpuUsage.toFloat().coerceIn(0f, 1f) },
+                modifier = Modifier.fillMaxWidth().height(4.dp),
+                color = accent,
+                trackColor = accent.copy(alpha = 0.12f)
+            )
+        }
+    }
+}
+
+@Composable
+private fun ResourceCard(resource: ProxmoxResource, accent: Color) {
+    val isRunning = resource.status == "running"
+    val typeLabel = if (resource.type == "qemu") "VM" else "LXC"
+    Surface(shape = RoundedCornerShape(16.dp), color = MaterialTheme.colorScheme.surfaceContainerLow) {
+        Row(modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 12.dp), horizontalArrangement = Arrangement.SpaceBetween, verticalAlignment = Alignment.CenterVertically) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(resource.name, style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                Text("$typeLabel on ${resource.node}", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+            Surface(shape = RoundedCornerShape(10.dp), color = if (isRunning) accent.copy(alpha = 0.12f) else MaterialTheme.colorScheme.surfaceContainer) {
+                Text(
+                    resource.status.replaceFirstChar { it.uppercase() },
+                    modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = if (isRunning) accent else MaterialTheme.colorScheme.onSurfaceVariant,
+                    fontWeight = FontWeight.SemiBold
+                )
+            }
+        }
+    }
+}
+
+private fun formatUptime(seconds: Long): String {
+    val days = seconds / 86400
+    val hours = (seconds % 86400) / 3600
+    return if (days > 0) "${days}d ${hours}h" else "${hours}h"
+}

--- a/HomelabAndroid/app/src/main/java/com/homelab/app/ui/proxmox/ProxmoxViewModel.kt
+++ b/HomelabAndroid/app/src/main/java/com/homelab/app/ui/proxmox/ProxmoxViewModel.kt
@@ -1,0 +1,73 @@
+package com.homelab.app.ui.proxmox
+
+import android.content.Context
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.homelab.app.data.repository.ProxmoxDashboardData
+import com.homelab.app.data.repository.ProxmoxRepository
+import com.homelab.app.data.repository.ServicesRepository
+import com.homelab.app.domain.model.ServiceInstance
+import com.homelab.app.util.ErrorHandler
+import com.homelab.app.util.ServiceType
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+sealed interface ProxmoxUiState {
+    data object Loading : ProxmoxUiState
+    data class Success(val data: ProxmoxDashboardData) : ProxmoxUiState
+    data class Error(val message: String) : ProxmoxUiState
+}
+
+@HiltViewModel
+class ProxmoxViewModel @Inject constructor(
+    private val repository: ProxmoxRepository,
+    private val servicesRepository: ServicesRepository,
+    savedStateHandle: SavedStateHandle,
+    @param:ApplicationContext private val context: Context
+) : ViewModel() {
+
+    val instanceId: String = checkNotNull(savedStateHandle["instanceId"])
+
+    private val _uiState = MutableStateFlow<ProxmoxUiState>(ProxmoxUiState.Loading)
+    val uiState: StateFlow<ProxmoxUiState> = _uiState
+
+    val instances: StateFlow<List<ServiceInstance>> = servicesRepository.instancesByType
+        .map { it[ServiceType.PROXMOX].orEmpty() }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
+    private var refreshJob: Job? = null
+
+    init {
+        refresh()
+    }
+
+    fun refresh() {
+        refreshJob?.cancel()
+        refreshJob = viewModelScope.launch {
+            _uiState.value = ProxmoxUiState.Loading
+            try {
+                val data = repository.getDashboard(instanceId)
+                _uiState.value = ProxmoxUiState.Success(data)
+            } catch (error: Exception) {
+                if (error is CancellationException) throw error
+                _uiState.value = ProxmoxUiState.Error(ErrorHandler.getMessage(context, error))
+            }
+        }
+    }
+
+    fun setPreferredInstance(newInstanceId: String) {
+        viewModelScope.launch {
+            servicesRepository.setPreferredInstance(ServiceType.PROXMOX, newInstanceId)
+        }
+    }
+}

--- a/HomelabAndroid/app/src/main/java/com/homelab/app/ui/sabnzbd/SABnzbdDashboardScreen.kt
+++ b/HomelabAndroid/app/src/main/java/com/homelab/app/ui/sabnzbd/SABnzbdDashboardScreen.kt
@@ -1,0 +1,191 @@
+package com.homelab.app.ui.sabnzbd
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.homelab.app.data.repository.SABnzbdDashboardData
+import com.homelab.app.data.repository.SABnzbdHistoryItem
+import com.homelab.app.data.repository.SABnzbdQueueItem
+import com.homelab.app.ui.components.ServiceIcon
+import com.homelab.app.ui.theme.primaryColor
+import com.homelab.app.util.ServiceType
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@Composable
+fun SABnzbdDashboardScreen(
+    onNavigateBack: () -> Unit,
+    onNavigateToInstance: (String) -> Unit,
+    viewModel: SABnzbdViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val accent = ServiceType.SABNZBD.primaryColor
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("SABnzbd") },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                actions = {
+                    IconButton(onClick = { viewModel.refresh() }) {
+                        Icon(Icons.Default.Refresh, contentDescription = "Refresh", tint = accent)
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = MaterialTheme.colorScheme.background)
+            )
+        }
+    ) { padding ->
+        when (val state = uiState) {
+            SABnzbdUiState.Loading -> {
+                Box(modifier = Modifier.fillMaxSize().padding(padding), contentAlignment = Alignment.Center) {
+                    CircularProgressIndicator(color = accent)
+                }
+            }
+            is SABnzbdUiState.Error -> {
+                Box(modifier = Modifier.fillMaxSize().padding(padding).padding(24.dp), contentAlignment = Alignment.Center) {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        Text(state.message, style = MaterialTheme.typography.bodyLarge, color = MaterialTheme.colorScheme.error)
+                        Spacer(modifier = Modifier.height(12.dp))
+                        TextButton(onClick = { viewModel.refresh() }) { Text("Retry") }
+                    }
+                }
+            }
+            is SABnzbdUiState.Success -> {
+                SABnzbdContent(padding = padding, data = state.data, accent = accent)
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun SABnzbdContent(padding: PaddingValues, data: SABnzbdDashboardData, accent: Color) {
+    LazyColumn(
+        modifier = Modifier.fillMaxSize().padding(padding),
+        contentPadding = PaddingValues(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        item {
+            Surface(shape = RoundedCornerShape(24.dp), color = MaterialTheme.colorScheme.surfaceContainerLow) {
+                Column(modifier = Modifier.fillMaxWidth().padding(20.dp), verticalArrangement = Arrangement.spacedBy(14.dp)) {
+                    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(14.dp)) {
+                        ServiceIcon(type = ServiceType.SABNZBD, size = 64.dp, iconSize = 36.dp, cornerRadius = 18.dp)
+                        Column {
+                            Text("SABnzbd", style = MaterialTheme.typography.headlineSmall, fontWeight = FontWeight.Bold)
+                            Text(
+                                text = "v${data.version}" + if (data.paused) " -- Paused" else "",
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    }
+
+                    FlowRow(horizontalArrangement = Arrangement.spacedBy(10.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                        MetricPill("Speed", data.speedBps, accent)
+                        MetricPill("Queue", data.queueCount.toString(), accent)
+                        MetricPill("Left", data.sizeLeft, accent)
+                        MetricPill("ETA", data.timeLeft, accent)
+                        MetricPill("Disk Free", data.diskSpaceFree, accent)
+                        MetricPill("History", data.historyCount.toString(), accent)
+                    }
+                }
+            }
+        }
+
+        if (data.queueItems.isNotEmpty()) {
+            item { Text("Queue", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold) }
+            items(data.queueItems, key = { "q-${it.id}" }) { item ->
+                QueueItemCard(item = item, accent = accent)
+            }
+        }
+
+        if (data.historyItems.isNotEmpty()) {
+            item { Text("History", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold) }
+            items(data.historyItems.take(15), key = { "h-${it.id}" }) { item ->
+                HistoryItemCard(item = item)
+            }
+        }
+    }
+}
+
+@Composable
+private fun MetricPill(label: String, value: String, accent: Color) {
+    Surface(shape = RoundedCornerShape(16.dp), color = accent.copy(alpha = 0.12f)) {
+        Column(modifier = Modifier.padding(horizontal = 14.dp, vertical = 10.dp)) {
+            Text(value, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold, color = accent)
+            Text(label, style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        }
+    }
+}
+
+@Composable
+private fun QueueItemCard(item: SABnzbdQueueItem, accent: Color) {
+    Surface(shape = RoundedCornerShape(16.dp), color = MaterialTheme.colorScheme.surfaceContainerLow) {
+        Column(modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 12.dp), verticalArrangement = Arrangement.spacedBy(6.dp)) {
+            Text(item.filename, style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold, maxLines = 2, overflow = TextOverflow.Ellipsis)
+            LinearProgressIndicator(
+                progress = { item.percentage / 100f },
+                modifier = Modifier.fillMaxWidth().height(6.dp),
+                color = accent,
+                trackColor = accent.copy(alpha = 0.12f)
+            )
+            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+                Text("${item.percentage}% -- ${item.sizeLeft}", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                Text(item.status, style = MaterialTheme.typography.labelMedium, color = accent)
+            }
+        }
+    }
+}
+
+@Composable
+private fun HistoryItemCard(item: SABnzbdHistoryItem) {
+    Surface(shape = RoundedCornerShape(16.dp), color = MaterialTheme.colorScheme.surfaceContainerLow) {
+        Column(modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 12.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            Text(item.name, style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold, maxLines = 2, overflow = TextOverflow.Ellipsis)
+            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+                Text(item.size, style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                Text(item.status, style = MaterialTheme.typography.labelMedium, color = if (item.status == "Completed") Color(0xFF16A34A) else MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+        }
+    }
+}

--- a/HomelabAndroid/app/src/main/java/com/homelab/app/ui/sabnzbd/SABnzbdViewModel.kt
+++ b/HomelabAndroid/app/src/main/java/com/homelab/app/ui/sabnzbd/SABnzbdViewModel.kt
@@ -1,0 +1,73 @@
+package com.homelab.app.ui.sabnzbd
+
+import android.content.Context
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.homelab.app.data.repository.SABnzbdDashboardData
+import com.homelab.app.data.repository.SABnzbdRepository
+import com.homelab.app.data.repository.ServicesRepository
+import com.homelab.app.domain.model.ServiceInstance
+import com.homelab.app.util.ErrorHandler
+import com.homelab.app.util.ServiceType
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+sealed interface SABnzbdUiState {
+    data object Loading : SABnzbdUiState
+    data class Success(val data: SABnzbdDashboardData) : SABnzbdUiState
+    data class Error(val message: String) : SABnzbdUiState
+}
+
+@HiltViewModel
+class SABnzbdViewModel @Inject constructor(
+    private val repository: SABnzbdRepository,
+    private val servicesRepository: ServicesRepository,
+    savedStateHandle: SavedStateHandle,
+    @param:ApplicationContext private val context: Context
+) : ViewModel() {
+
+    val instanceId: String = checkNotNull(savedStateHandle["instanceId"])
+
+    private val _uiState = MutableStateFlow<SABnzbdUiState>(SABnzbdUiState.Loading)
+    val uiState: StateFlow<SABnzbdUiState> = _uiState
+
+    val instances: StateFlow<List<ServiceInstance>> = servicesRepository.instancesByType
+        .map { it[ServiceType.SABNZBD].orEmpty() }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
+    private var refreshJob: Job? = null
+
+    init {
+        refresh()
+    }
+
+    fun refresh() {
+        refreshJob?.cancel()
+        refreshJob = viewModelScope.launch {
+            _uiState.value = SABnzbdUiState.Loading
+            try {
+                val data = repository.getDashboard(instanceId)
+                _uiState.value = SABnzbdUiState.Success(data)
+            } catch (error: Exception) {
+                if (error is CancellationException) throw error
+                _uiState.value = SABnzbdUiState.Error(ErrorHandler.getMessage(context, error))
+            }
+        }
+    }
+
+    fun setPreferredInstance(newInstanceId: String) {
+        viewModelScope.launch {
+            servicesRepository.setPreferredInstance(ServiceType.SABNZBD, newInstanceId)
+        }
+    }
+}

--- a/HomelabAndroid/app/src/main/java/com/homelab/app/ui/tdarr/TdarrDashboardScreen.kt
+++ b/HomelabAndroid/app/src/main/java/com/homelab/app/ui/tdarr/TdarrDashboardScreen.kt
@@ -1,0 +1,169 @@
+package com.homelab.app.ui.tdarr
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.homelab.app.data.repository.TdarrDashboardData
+import com.homelab.app.data.repository.TdarrNode
+import com.homelab.app.ui.components.ServiceIcon
+import com.homelab.app.ui.theme.primaryColor
+import com.homelab.app.util.ServiceType
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@Composable
+fun TdarrDashboardScreen(
+    onNavigateBack: () -> Unit,
+    onNavigateToInstance: (String) -> Unit,
+    viewModel: TdarrViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val accent = ServiceType.TDARR.primaryColor
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Tdarr") },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                actions = {
+                    IconButton(onClick = { viewModel.refresh() }) {
+                        Icon(Icons.Default.Refresh, contentDescription = "Refresh", tint = accent)
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = MaterialTheme.colorScheme.background)
+            )
+        }
+    ) { padding ->
+        when (val state = uiState) {
+            TdarrUiState.Loading -> {
+                Box(modifier = Modifier.fillMaxSize().padding(padding), contentAlignment = Alignment.Center) {
+                    CircularProgressIndicator(color = accent)
+                }
+            }
+            is TdarrUiState.Error -> {
+                Box(modifier = Modifier.fillMaxSize().padding(padding).padding(24.dp), contentAlignment = Alignment.Center) {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        Text(state.message, style = MaterialTheme.typography.bodyLarge, color = MaterialTheme.colorScheme.error)
+                        Spacer(modifier = Modifier.height(12.dp))
+                        TextButton(onClick = { viewModel.refresh() }) { Text("Retry") }
+                    }
+                }
+            }
+            is TdarrUiState.Success -> {
+                TdarrContent(padding = padding, data = state.data, accent = accent)
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun TdarrContent(padding: PaddingValues, data: TdarrDashboardData, accent: Color) {
+    LazyColumn(
+        modifier = Modifier.fillMaxSize().padding(padding),
+        contentPadding = PaddingValues(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        item {
+            Surface(shape = RoundedCornerShape(24.dp), color = MaterialTheme.colorScheme.surfaceContainerLow) {
+                Column(modifier = Modifier.fillMaxWidth().padding(20.dp), verticalArrangement = Arrangement.spacedBy(14.dp)) {
+                    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(14.dp)) {
+                        ServiceIcon(type = ServiceType.TDARR, size = 64.dp, iconSize = 36.dp, cornerRadius = 18.dp)
+                        Column {
+                            Text("Tdarr", style = MaterialTheme.typography.headlineSmall, fontWeight = FontWeight.Bold)
+                            Text("Media optimization", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                        }
+                    }
+
+                    FlowRow(horizontalArrangement = Arrangement.spacedBy(10.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                        MetricPill("Files", data.totalFiles.toString(), accent)
+                        MetricPill("Transcodes", data.totalTranscodeCount.toString(), accent)
+                        MetricPill("Health Checks", data.totalHealthCheckCount.toString(), accent)
+                        MetricPill("Saved", data.sizeReduction, accent)
+                        MetricPill("Nodes", data.nodes.size.toString(), accent)
+                        if (data.tdarrScore != "N/A") {
+                            MetricPill("Score", data.tdarrScore, accent)
+                        }
+                    }
+                }
+            }
+        }
+
+        if (data.nodes.isNotEmpty()) {
+            item { Text("Nodes", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold) }
+            items(data.nodes, key = { "node-${it.id}" }) { node ->
+                NodeCard(node = node, accent = accent)
+            }
+        }
+    }
+}
+
+@Composable
+private fun MetricPill(label: String, value: String, accent: Color) {
+    Surface(shape = RoundedCornerShape(16.dp), color = accent.copy(alpha = 0.12f)) {
+        Column(modifier = Modifier.padding(horizontal = 14.dp, vertical = 10.dp)) {
+            Text(value, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold, color = accent)
+            Text(label, style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        }
+    }
+}
+
+@Composable
+private fun NodeCard(node: TdarrNode, accent: Color) {
+    Surface(shape = RoundedCornerShape(16.dp), color = MaterialTheme.colorScheme.surfaceContainerLow) {
+        Row(modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 12.dp), horizontalArrangement = Arrangement.SpaceBetween, verticalAlignment = Alignment.CenterVertically) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(node.name, style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                Text("${node.workers} worker(s)", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+            Surface(shape = RoundedCornerShape(10.dp), color = if (node.online) accent.copy(alpha = 0.12f) else MaterialTheme.colorScheme.errorContainer) {
+                Text(
+                    if (node.online) "Online" else "Offline",
+                    modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = if (node.online) accent else MaterialTheme.colorScheme.error,
+                    fontWeight = FontWeight.SemiBold
+                )
+            }
+        }
+    }
+}

--- a/HomelabAndroid/app/src/main/java/com/homelab/app/ui/tdarr/TdarrViewModel.kt
+++ b/HomelabAndroid/app/src/main/java/com/homelab/app/ui/tdarr/TdarrViewModel.kt
@@ -1,0 +1,73 @@
+package com.homelab.app.ui.tdarr
+
+import android.content.Context
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.homelab.app.data.repository.TdarrDashboardData
+import com.homelab.app.data.repository.TdarrRepository
+import com.homelab.app.data.repository.ServicesRepository
+import com.homelab.app.domain.model.ServiceInstance
+import com.homelab.app.util.ErrorHandler
+import com.homelab.app.util.ServiceType
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+sealed interface TdarrUiState {
+    data object Loading : TdarrUiState
+    data class Success(val data: TdarrDashboardData) : TdarrUiState
+    data class Error(val message: String) : TdarrUiState
+}
+
+@HiltViewModel
+class TdarrViewModel @Inject constructor(
+    private val repository: TdarrRepository,
+    private val servicesRepository: ServicesRepository,
+    savedStateHandle: SavedStateHandle,
+    @param:ApplicationContext private val context: Context
+) : ViewModel() {
+
+    val instanceId: String = checkNotNull(savedStateHandle["instanceId"])
+
+    private val _uiState = MutableStateFlow<TdarrUiState>(TdarrUiState.Loading)
+    val uiState: StateFlow<TdarrUiState> = _uiState
+
+    val instances: StateFlow<List<ServiceInstance>> = servicesRepository.instancesByType
+        .map { it[ServiceType.TDARR].orEmpty() }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
+    private var refreshJob: Job? = null
+
+    init {
+        refresh()
+    }
+
+    fun refresh() {
+        refreshJob?.cancel()
+        refreshJob = viewModelScope.launch {
+            _uiState.value = TdarrUiState.Loading
+            try {
+                val data = repository.getDashboard(instanceId)
+                _uiState.value = TdarrUiState.Success(data)
+            } catch (error: Exception) {
+                if (error is CancellationException) throw error
+                _uiState.value = TdarrUiState.Error(ErrorHandler.getMessage(context, error))
+            }
+        }
+    }
+
+    fun setPreferredInstance(newInstanceId: String) {
+        viewModelScope.launch {
+            servicesRepository.setPreferredInstance(ServiceType.TDARR, newInstanceId)
+        }
+    }
+}

--- a/HomelabAndroid/app/src/main/java/com/homelab/app/ui/theme/ServiceTypeExt.kt
+++ b/HomelabAndroid/app/src/main/java/com/homelab/app/ui/theme/ServiceTypeExt.kt
@@ -13,8 +13,14 @@ import androidx.compose.material.icons.filled.Security
 import androidx.compose.material.icons.filled.Source
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.filled.Storage
+import androidx.compose.material.icons.filled.Backup
+import androidx.compose.material.icons.filled.CameraAlt
+import androidx.compose.material.icons.filled.CloudDownload
+import androidx.compose.material.icons.filled.Dashboard
+import androidx.compose.material.icons.filled.Memory
 import androidx.compose.material.icons.filled.Subtitles
 import androidx.compose.material.icons.filled.Tv
+import androidx.compose.material.icons.filled.Videocam
 import androidx.compose.material.icons.filled.VpnLock
 import androidx.compose.material.icons.filled.Widgets
 import androidx.compose.material3.MaterialTheme
@@ -53,6 +59,13 @@ val ServiceType.primaryColor: Color
         ServiceType.BAZARR -> Color(0xFF2563EB)
         ServiceType.GLUETUN -> Color(0xFF06B6D4)
         ServiceType.FLARESOLVERR -> Color(0xFFFF4500)
+        ServiceType.JELLYFIN -> Color(0xFF00A4DC)
+        ServiceType.IMMICH -> Color(0xFF4250AF)
+        ServiceType.GRAFANA -> Color(0xFFF46800)
+        ServiceType.SABNZBD -> Color(0xFFEAB12B)
+        ServiceType.PROXMOX -> Color(0xFFE57000)
+        ServiceType.PROXMOX_BACKUP_SERVER -> Color(0xFFE57000)
+        ServiceType.TDARR -> Color(0xFF6366F1)
         ServiceType.UNKNOWN -> if (isThemeDark()) Color.LightGray else Color.Gray
     }
 
@@ -82,6 +95,13 @@ val ServiceType.backgroundColor: Color
         ServiceType.BAZARR -> Color(0xFF2563EB).copy(alpha = 0.12f)
         ServiceType.GLUETUN -> Color(0xFF06B6D4).copy(alpha = 0.12f)
         ServiceType.FLARESOLVERR -> Color(0xFFFF4500).copy(alpha = 0.12f)
+        ServiceType.JELLYFIN -> Color(0xFF00A4DC).copy(alpha = 0.12f)
+        ServiceType.IMMICH -> Color(0xFF4250AF).copy(alpha = 0.12f)
+        ServiceType.GRAFANA -> Color(0xFFF46800).copy(alpha = 0.12f)
+        ServiceType.SABNZBD -> Color(0xFFEAB12B).copy(alpha = 0.12f)
+        ServiceType.PROXMOX -> Color(0xFFE57000).copy(alpha = 0.12f)
+        ServiceType.PROXMOX_BACKUP_SERVER -> Color(0xFFE57000).copy(alpha = 0.12f)
+        ServiceType.TDARR -> Color(0xFF6366F1).copy(alpha = 0.12f)
         ServiceType.UNKNOWN -> if (isThemeDark()) Color(0xFF334155) else Color(0xFFF1F5F9)
     }
 
@@ -110,6 +130,13 @@ val ServiceType.iconUrl: String
         ServiceType.BAZARR -> "https://cdn.jsdelivr.net/gh/selfhst/icons/png/bazarr.png"
         ServiceType.GLUETUN -> "https://cdn.jsdelivr.net/gh/selfhst/icons/png/gluetun.png"
         ServiceType.FLARESOLVERR -> "https://cdn.jsdelivr.net/gh/selfhst/icons/png/flaresolverr.png"
+        ServiceType.JELLYFIN -> "https://cdn.jsdelivr.net/gh/selfhst/icons/png/jellyfin.png"
+        ServiceType.IMMICH -> "https://cdn.jsdelivr.net/gh/selfhst/icons/png/immich.png"
+        ServiceType.GRAFANA -> "https://cdn.jsdelivr.net/gh/selfhst/icons/png/grafana.png"
+        ServiceType.SABNZBD -> "https://cdn.jsdelivr.net/gh/selfhst/icons/png/sabnzbd.png"
+        ServiceType.PROXMOX -> "https://cdn.jsdelivr.net/gh/selfhst/icons/png/proxmox.png"
+        ServiceType.PROXMOX_BACKUP_SERVER -> "https://cdn.jsdelivr.net/gh/selfhst/icons/png/proxmox-backup-server.png"
+        ServiceType.TDARR -> "https://cdn.jsdelivr.net/gh/selfhst/icons/png/tdarr.png"
         ServiceType.UNKNOWN -> ""
     }
 
@@ -171,5 +198,12 @@ val ServiceType.fallbackIcon: ImageVector
         ServiceType.BAZARR -> Icons.Default.Subtitles
         ServiceType.GLUETUN -> Icons.Default.VpnLock
         ServiceType.FLARESOLVERR -> Icons.Default.LocalFireDepartment
+        ServiceType.JELLYFIN -> Icons.Default.Videocam
+        ServiceType.IMMICH -> Icons.Default.CameraAlt
+        ServiceType.GRAFANA -> Icons.Default.Dashboard
+        ServiceType.SABNZBD -> Icons.Default.CloudDownload
+        ServiceType.PROXMOX -> Icons.Default.Memory
+        ServiceType.PROXMOX_BACKUP_SERVER -> Icons.Default.Backup
+        ServiceType.TDARR -> Icons.Default.Videocam
         ServiceType.UNKNOWN -> Icons.Default.Widgets
     }

--- a/HomelabAndroid/app/src/main/java/com/homelab/app/util/ServiceType.kt
+++ b/HomelabAndroid/app/src/main/java/com/homelab/app/util/ServiceType.kt
@@ -29,6 +29,13 @@ enum class ServiceType(val displayName: String) {
     BAZARR("Bazarr"),
     GLUETUN("Gluetun"),
     FLARESOLVERR("FlareSolverr"),
+    JELLYFIN("Jellyfin"),
+    IMMICH("Immich"),
+    GRAFANA("Grafana"),
+    SABNZBD("SABnzbd"),
+    PROXMOX("Proxmox VE"),
+    PROXMOX_BACKUP_SERVER("Proxmox Backup Server"),
+    TDARR("Tdarr"),
     UNKNOWN("Unknown");
 
     companion object {
@@ -41,7 +48,10 @@ enum class ServiceType(val displayName: String) {
             PROWLARR,
             BAZARR,
             GLUETUN,
-            FLARESOLVERR
+            FLARESOLVERR,
+            JELLYFIN,
+            SABNZBD,
+            TDARR
         )
 
         val homeTypes: List<ServiceType> = entries.filter { it != UNKNOWN && it !in arrStackTypes }
@@ -57,6 +67,17 @@ enum class ServiceType(val displayName: String) {
                 "TECHNITIUMDNS" -> TECHNITIUM
                 "PANGOLIN" -> PANGOLIN
                 "DOCKHAND" -> DOCKHAND
+                "JELLYFIN" -> JELLYFIN
+                "IMMICH" -> IMMICH
+                "GRAFANA" -> GRAFANA
+                "SABNZBD" -> SABNZBD
+                "PROXMOX",
+                "PROXMOX_VE",
+                "PROXMOXVE" -> PROXMOX
+                "PBS",
+                "PROXMOX_BACKUP_SERVER",
+                "PROXMOXBACKUPSERVER" -> PROXMOX_BACKUP_SERVER
+                "TDARR" -> TDARR
                 else -> entries.firstOrNull { it.name == normalized } ?: UNKNOWN
             }
         }

--- a/HomelabAndroid/app/src/main/res/values/strings.xml
+++ b/HomelabAndroid/app/src/main/res/values/strings.xml
@@ -1131,6 +1131,13 @@
     <string name="login_hint_bazarr">Use your Bazarr API key from Settings → General.</string>
     <string name="login_hint_gluetun">Add URL only, API key is optional if your endpoint is protected.</string>
     <string name="login_hint_flaresolverr">Add URL only, API key is optional if your endpoint is protected.</string>
+    <string name="login_hint_jellyfin">Use the Jellyfin API key from Dashboard > API Keys.</string>
+    <string name="login_hint_immich">Use the Immich API key from Administration > API Keys.</string>
+    <string name="login_hint_grafana">Use a Grafana Service Account token or API key with Viewer role or higher.</string>
+    <string name="login_hint_sabnzbd">Use the SABnzbd API key from Config > General > Security.</string>
+    <string name="login_hint_proxmox">Use a PVE API token in the format user@realm!tokenid=secret.</string>
+    <string name="login_hint_pbs">Use a PBS API token in the format user@realm!tokenid=secret.</string>
+    <string name="login_hint_tdarr">Add URL only. API key is optional unless Tdarr authentication is enabled.</string>
     <string name="login_api_key_optional_label">API Key (optional)</string>
 
     <string name="settings_group_home_title">Home Services</string>

--- a/HomelabSwift/Homelab/Models/ServiceType.swift
+++ b/HomelabSwift/Homelab/Models/ServiceType.swift
@@ -24,6 +24,13 @@ public enum ServiceType: String, CaseIterable, Identifiable, Codable, Hashable, 
     case bazarr
     case gluetun
     case flaresolverr
+    case jellyfin
+    case immich
+    case grafana
+    case sabnzbd
+    case proxmox
+    case proxmoxBackupServer = "proxmox_backup_server"
+    case tdarr
 
     public var id: String { rawValue }
 
@@ -52,6 +59,8 @@ public enum ServiceType: String, CaseIterable, Identifiable, Codable, Hashable, 
             return .dockhand
         case "pangolin":
             return .pangolin
+        case "proxmox_backup_server", "proxmoxbackupserver", "pbs":
+            return .proxmoxBackupServer
         default:
             return nil
         }
@@ -75,13 +84,16 @@ public enum ServiceType: String, CaseIterable, Identifiable, Codable, Hashable, 
     }
 
     public static let mediaServices: [ServiceType] = [
+        .jellyfin,
         .radarr,
         .sonarr,
         .lidarr,
         .qbittorrent,
+        .sabnzbd,
         .jellyseerr,
         .prowlarr,
         .bazarr,
+        .tdarr,
         .gluetun,
         .flaresolverr
     ]
@@ -119,6 +131,13 @@ public enum ServiceType: String, CaseIterable, Identifiable, Codable, Hashable, 
         case .bazarr:             return "Bazarr"
         case .gluetun:            return "Gluetun"
         case .flaresolverr:       return "FlareSolverr"
+        case .jellyfin:           return "Jellyfin"
+        case .immich:             return "Immich"
+        case .grafana:            return "Grafana"
+        case .sabnzbd:            return "SABnzbd"
+        case .proxmox:            return "Proxmox VE"
+        case .proxmoxBackupServer: return "Proxmox Backup Server"
+        case .tdarr:              return "Tdarr"
         }
     }
 
@@ -149,6 +168,13 @@ public enum ServiceType: String, CaseIterable, Identifiable, Codable, Hashable, 
         case .bazarr:             return t.serviceBazarrDesc
         case .gluetun:            return t.serviceGluetunDesc
         case .flaresolverr:       return t.serviceFlaresolverrDesc
+        case .jellyfin:           return "Media server dashboard"
+        case .immich:             return "Photo and video backup"
+        case .grafana:            return "Monitoring and observability"
+        case .sabnzbd:            return "Usenet download client"
+        case .proxmox:            return "Virtualization management"
+        case .proxmoxBackupServer: return "Backup server dashboard"
+        case .tdarr:              return "Media transcoding manager"
         }
     }
 
@@ -177,6 +203,13 @@ public enum ServiceType: String, CaseIterable, Identifiable, Codable, Hashable, 
         case .bazarr:             return "text.bubble.fill"
         case .gluetun:            return "lock.shield.fill"
         case .flaresolverr:       return "flame.fill"
+        case .jellyfin:           return "play.rectangle.fill"
+        case .immich:             return "photo.on.rectangle.angled"
+        case .grafana:            return "chart.bar.xaxis"
+        case .sabnzbd:            return "arrow.down.doc.fill"
+        case .proxmox:            return "cpu.fill"
+        case .proxmoxBackupServer: return "externaldrive.fill.badge.checkmark"
+        case .tdarr:              return "waveform.path"
         }
     }
 
@@ -205,6 +238,13 @@ public enum ServiceType: String, CaseIterable, Identifiable, Codable, Hashable, 
         case .bazarr:             return "https://cdn.jsdelivr.net/gh/selfhst/icons/png/bazarr.png"
         case .gluetun:            return "https://cdn.jsdelivr.net/gh/selfhst/icons/png/gluetun.png"
         case .flaresolverr:       return "https://cdn.jsdelivr.net/gh/selfhst/icons/png/flaresolverr.png"
+        case .jellyfin:           return "https://cdn.jsdelivr.net/gh/selfhst/icons/png/jellyfin.png"
+        case .immich:             return "https://cdn.jsdelivr.net/gh/selfhst/icons/png/immich.png"
+        case .grafana:            return "https://cdn.jsdelivr.net/gh/selfhst/icons/png/grafana.png"
+        case .sabnzbd:            return "https://cdn.jsdelivr.net/gh/selfhst/icons/png/sabnzbd.png"
+        case .proxmox:            return "https://cdn.jsdelivr.net/gh/selfhst/icons/png/proxmox.png"
+        case .proxmoxBackupServer: return "https://cdn.jsdelivr.net/gh/selfhst/icons/png/proxmox-backup-server.png"
+        case .tdarr:              return "https://cdn.jsdelivr.net/gh/selfhst/icons/png/tdarr.png"
         }
     }
 
@@ -234,6 +274,13 @@ public enum ServiceType: String, CaseIterable, Identifiable, Codable, Hashable, 
         case .bazarr:             slug = "bazarr"
         case .gluetun:            slug = "gluetun"
         case .flaresolverr:       slug = "flaresolverr"
+        case .jellyfin:           slug = "jellyfin"
+        case .immich:             slug = "immich"
+        case .grafana:            slug = "grafana"
+        case .sabnzbd:            slug = "sabnzbd"
+        case .proxmox:            slug = "proxmox"
+        case .proxmoxBackupServer: slug = "proxmox-backup-server"
+        case .tdarr:              slug = "tdarr"
         }
         var orderedCandidates: [String] = []
         let primary = iconUrl.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -277,6 +324,13 @@ public enum ServiceType: String, CaseIterable, Identifiable, Codable, Hashable, 
         case .bazarr:             return "service-bazarr"
         case .gluetun:            return "service-gluetun"
         case .flaresolverr:       return "service-flaresolverr"
+        case .jellyfin:           return "service-jellyfin"
+        case .immich:             return "service-immich"
+        case .grafana:            return "service-grafana"
+        case .sabnzbd:            return "service-sabnzbd"
+        case .proxmox:            return "service-proxmox"
+        case .proxmoxBackupServer: return "service-proxmox-backup-server"
+        case .tdarr:              return "service-tdarr"
         }
     }
 
@@ -305,6 +359,13 @@ public enum ServiceType: String, CaseIterable, Identifiable, Codable, Hashable, 
         case .bazarr:             return ServiceColorSet(primary: Color(hex: "#2563EB"), dark: Color(hex: "#1D4ED8"), bg: Color(hex: "#2563EB").opacity(0.09))
         case .gluetun:            return ServiceColorSet(primary: Color(hex: "#06B6D4"), dark: Color(hex: "#0891B2"), bg: Color(hex: "#06B6D4").opacity(0.09))
         case .flaresolverr:       return ServiceColorSet(primary: Color(hex: "#FF4500"), dark: Color(hex: "#CC3700"), bg: Color(hex: "#FF4500").opacity(0.09))
+        case .jellyfin:           return ServiceColorSet(primary: Color(hex: "#00A4DC"), dark: Color(hex: "#0082B0"), bg: Color(hex: "#00A4DC").opacity(0.09))
+        case .immich:             return ServiceColorSet(primary: Color(hex: "#4250AF"), dark: Color(hex: "#333F8C"), bg: Color(hex: "#4250AF").opacity(0.09))
+        case .grafana:            return ServiceColorSet(primary: Color(hex: "#F46800"), dark: Color(hex: "#C35300"), bg: Color(hex: "#F46800").opacity(0.09))
+        case .sabnzbd:            return ServiceColorSet(primary: Color(hex: "#EAB12B"), dark: Color(hex: "#C89422"), bg: Color(hex: "#EAB12B").opacity(0.09))
+        case .proxmox:            return ServiceColorSet(primary: Color(hex: "#E57000"), dark: Color(hex: "#B85A00"), bg: Color(hex: "#E57000").opacity(0.09))
+        case .proxmoxBackupServer: return ServiceColorSet(primary: Color(hex: "#E57000"), dark: Color(hex: "#B85A00"), bg: Color(hex: "#E57000").opacity(0.09))
+        case .tdarr:              return ServiceColorSet(primary: Color(hex: "#6366F1"), dark: Color(hex: "#4F46E5"), bg: Color(hex: "#6366F1").opacity(0.09))
         }
     }
 }

--- a/HomelabSwift/Homelab/Networking/Grafana/GrafanaAPIClient.swift
+++ b/HomelabSwift/Homelab/Networking/Grafana/GrafanaAPIClient.swift
@@ -1,0 +1,148 @@
+import Foundation
+
+struct GrafanaHealthInfo: Sendable {
+    let version: String
+    let commit: String?
+    let database: String?
+}
+
+struct GrafanaDashboardSummary: Sendable {
+    let id: Int
+    let uid: String
+    let title: String
+    let type: String?
+    let url: String?
+}
+
+struct GrafanaAlert: Sendable {
+    let name: String
+    let state: String
+    let severity: String?
+}
+
+actor GrafanaAPIClient {
+    private let engine: BaseNetworkEngine
+    private var baseURL: String = ""
+    private var fallbackURL: String = ""
+    private var apiKey: String = ""
+
+    init(instanceId: UUID) {
+        self.engine = BaseNetworkEngine(serviceType: .grafana, instanceId: instanceId)
+    }
+
+    func configure(url: String, apiKey: String, fallbackUrl: String? = nil) {
+        self.baseURL = Self.cleanURL(url)
+        self.fallbackURL = Self.cleanURL(fallbackUrl ?? "")
+        self.apiKey = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    func ping() async -> Bool {
+        guard !baseURL.isEmpty, !apiKey.isEmpty else { return false }
+        let path = "/api/health"
+        let primary = await engine.pingURL(baseURL + path, extraHeaders: authHeaders())
+        if primary { return true }
+        guard !fallbackURL.isEmpty else { return false }
+        return await engine.pingURL(fallbackURL + path, extraHeaders: authHeaders())
+    }
+
+    func authenticate(url: String, apiKey: String, fallbackUrl: String? = nil) async throws {
+        let cleanedURL = Self.cleanURL(url)
+        let cleanedFallback = Self.cleanURL(fallbackUrl ?? "")
+        let trimmedKey = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !cleanedURL.isEmpty, !trimmedKey.isEmpty else {
+            throw APIError.notConfigured
+        }
+
+        _ = try await engine.requestData(
+            baseURL: cleanedURL,
+            fallbackURL: cleanedFallback,
+            path: "/api/health",
+            headers: ["Authorization": "Bearer \(trimmedKey)", "Accept": "application/json"]
+        )
+    }
+
+    func getHealth() async throws -> GrafanaHealthInfo {
+        let data = try await engine.requestData(
+            baseURL: baseURL,
+            fallbackURL: fallbackURL,
+            path: "/api/health",
+            headers: authHeaders()
+        )
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw APIError.decodingError(NSError(domain: "Grafana", code: 0, userInfo: [NSLocalizedDescriptionKey: "Invalid JSON"]))
+        }
+        return GrafanaHealthInfo(
+            version: stringValue(json["version"]) ?? "Unknown",
+            commit: stringValue(json["commit"]),
+            database: stringValue(json["database"])
+        )
+    }
+
+    func getDashboards() async throws -> [GrafanaDashboardSummary] {
+        let data = try await engine.requestData(
+            baseURL: baseURL,
+            fallbackURL: fallbackURL,
+            path: "/api/search?type=dash-db",
+            headers: authHeaders()
+        )
+        guard let rows = try JSONSerialization.jsonObject(with: data) as? [[String: Any]] else {
+            return []
+        }
+        return rows.compactMap { row in
+            guard let id = intValue(row["id"]), id > 0 else { return nil }
+            return GrafanaDashboardSummary(
+                id: id,
+                uid: stringValue(row["uid"]) ?? "",
+                title: stringValue(row["title"]) ?? "Untitled",
+                type: stringValue(row["type"]),
+                url: stringValue(row["url"])
+            )
+        }
+    }
+
+    func getAlerts() async throws -> [GrafanaAlert] {
+        let data = try await engine.requestData(
+            baseURL: baseURL,
+            fallbackURL: fallbackURL,
+            path: "/api/alertmanager/grafana/api/v2/alerts",
+            headers: authHeaders()
+        )
+        guard let rows = try JSONSerialization.jsonObject(with: data) as? [[String: Any]] else {
+            return []
+        }
+        return rows.compactMap { row in
+            let labels = row["labels"] as? [String: Any]
+            let name = stringValue(labels?["alertname"]) ?? stringValue(row["alertname"]) ?? "Unknown"
+            let status = row["status"] as? [String: Any]
+            let state = stringValue(status?["state"]) ?? stringValue(row["state"]) ?? "unknown"
+            let severity = stringValue(labels?["severity"])
+            return GrafanaAlert(name: name, state: state, severity: severity)
+        }
+    }
+
+    private func authHeaders() -> [String: String] {
+        return [
+            "Authorization": "Bearer \(self.apiKey)",
+            "Accept": "application/json"
+        ]
+    }
+
+    private static func cleanURL(_ value: String) -> String {
+        value
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .replacingOccurrences(of: "/+$", with: "", options: .regularExpression)
+    }
+
+    private func stringValue(_ value: Any?) -> String? {
+        guard let text = value as? String else { return nil }
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private func intValue(_ value: Any?) -> Int? {
+        if let v = value as? Int { return v }
+        if let v = value as? Double { return Int(v) }
+        if let v = value as? String { return Int(v) }
+        return nil
+    }
+}

--- a/HomelabSwift/Homelab/Networking/Immich/ImmichAPIClient.swift
+++ b/HomelabSwift/Homelab/Networking/Immich/ImmichAPIClient.swift
@@ -1,0 +1,178 @@
+import Foundation
+
+struct ImmichServerInfo: Sendable {
+    let version: String
+    let isInitialized: Bool
+}
+
+struct ImmichServerStatistics: Sendable {
+    let totalPhotos: Int
+    let totalVideos: Int
+    let totalSize: Int64
+    let usageByUser: [ImmichUserUsage]
+}
+
+struct ImmichUserUsage: Sendable {
+    let userName: String
+    let photos: Int
+    let videos: Int
+    let usage: Int64
+}
+
+struct ImmichAssetStatistics: Sendable {
+    let images: Int
+    let videos: Int
+    let total: Int
+}
+
+actor ImmichAPIClient {
+    private let engine: BaseNetworkEngine
+    private var baseURL: String = ""
+    private var fallbackURL: String = ""
+    private var apiKey: String = ""
+
+    init(instanceId: UUID) {
+        self.engine = BaseNetworkEngine(serviceType: .immich, instanceId: instanceId)
+    }
+
+    func configure(url: String, apiKey: String, fallbackUrl: String? = nil) {
+        self.baseURL = Self.cleanURL(url)
+        self.fallbackURL = Self.cleanURL(fallbackUrl ?? "")
+        self.apiKey = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    func ping() async -> Bool {
+        guard !baseURL.isEmpty, !apiKey.isEmpty else { return false }
+        let path = "/api/server/info"
+        let primary = await engine.pingURL(baseURL + path, extraHeaders: authHeaders())
+        if primary { return true }
+        guard !fallbackURL.isEmpty else { return false }
+        return await engine.pingURL(fallbackURL + path, extraHeaders: authHeaders())
+    }
+
+    func authenticate(url: String, apiKey: String, fallbackUrl: String? = nil) async throws {
+        let cleanedURL = Self.cleanURL(url)
+        let cleanedFallback = Self.cleanURL(fallbackUrl ?? "")
+        let trimmedKey = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !cleanedURL.isEmpty, !trimmedKey.isEmpty else {
+            throw APIError.notConfigured
+        }
+
+        _ = try await engine.requestData(
+            baseURL: cleanedURL,
+            fallbackURL: cleanedFallback,
+            path: "/api/server/info",
+            headers: ["x-api-key": trimmedKey, "Accept": "application/json"]
+        )
+    }
+
+    func getServerInfo() async throws -> ImmichServerInfo {
+        let data = try await engine.requestData(
+            baseURL: baseURL,
+            fallbackURL: fallbackURL,
+            path: "/api/server/info",
+            headers: authHeaders()
+        )
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw APIError.decodingError(NSError(domain: "Immich", code: 0, userInfo: [NSLocalizedDescriptionKey: "Invalid JSON"]))
+        }
+        return ImmichServerInfo(
+            version: stringValue(json["version"]) ?? "Unknown",
+            isInitialized: boolValue(json["isInitialized"]) ?? true
+        )
+    }
+
+    func getServerStatistics() async throws -> ImmichServerStatistics {
+        let data = try await engine.requestData(
+            baseURL: baseURL,
+            fallbackURL: fallbackURL,
+            path: "/api/server/statistics",
+            headers: authHeaders()
+        )
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw APIError.decodingError(NSError(domain: "Immich", code: 0, userInfo: [NSLocalizedDescriptionKey: "Invalid JSON"]))
+        }
+
+        let usageByUser: [ImmichUserUsage]
+        if let users = json["usageByUser"] as? [[String: Any]] {
+            usageByUser = users.compactMap { user in
+                let name = stringValue(user["userName"]) ?? stringValue(user["userFirstName"]) ?? "Unknown"
+                return ImmichUserUsage(
+                    userName: name,
+                    photos: intValue(user["photos"]),
+                    videos: intValue(user["videos"]),
+                    usage: int64Value(user["usage"])
+                )
+            }
+        } else {
+            usageByUser = []
+        }
+
+        return ImmichServerStatistics(
+            totalPhotos: intValue(json["photos"]),
+            totalVideos: intValue(json["videos"]),
+            totalSize: int64Value(json["usage"]),
+            usageByUser: usageByUser
+        )
+    }
+
+    func getAssetStatistics() async throws -> ImmichAssetStatistics {
+        let data = try await engine.requestData(
+            baseURL: baseURL,
+            fallbackURL: fallbackURL,
+            path: "/api/assets/statistics",
+            headers: authHeaders()
+        )
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw APIError.decodingError(NSError(domain: "Immich", code: 0, userInfo: [NSLocalizedDescriptionKey: "Invalid JSON"]))
+        }
+        let images = intValue(json["images"])
+        let videos = intValue(json["videos"])
+        let total = intValue(json["total"])
+        return ImmichAssetStatistics(
+            images: images,
+            videos: videos,
+            total: total > 0 ? total : images + videos
+        )
+    }
+
+    private func authHeaders() -> [String: String] {
+        return [
+            "x-api-key": self.apiKey,
+            "Accept": "application/json"
+        ]
+    }
+
+    private static func cleanURL(_ value: String) -> String {
+        value
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .replacingOccurrences(of: "/+$", with: "", options: .regularExpression)
+    }
+
+    private func stringValue(_ value: Any?) -> String? {
+        guard let text = value as? String else { return nil }
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private func intValue(_ value: Any?) -> Int {
+        if let v = value as? Int { return v }
+        if let v = value as? Double { return Int(v) }
+        if let v = value as? String, let i = Int(v) { return i }
+        return 0
+    }
+
+    private func int64Value(_ value: Any?) -> Int64 {
+        if let v = value as? Int64 { return v }
+        if let v = value as? Int { return Int64(v) }
+        if let v = value as? Double { return Int64(v) }
+        if let v = value as? String, let i = Int64(v) { return i }
+        return 0
+    }
+
+    private func boolValue(_ value: Any?) -> Bool? {
+        if let v = value as? Bool { return v }
+        if let v = value as? Int { return v != 0 }
+        return nil
+    }
+}

--- a/HomelabSwift/Homelab/Networking/Jellyfin/JellyfinAPIClient.swift
+++ b/HomelabSwift/Homelab/Networking/Jellyfin/JellyfinAPIClient.swift
@@ -1,0 +1,185 @@
+import Foundation
+
+struct JellyfinSystemInfo: Sendable {
+    let serverName: String
+    let version: String
+    let operatingSystem: String?
+    let hasUpdateAvailable: Bool
+}
+
+struct JellyfinSession: Sendable {
+    let id: String
+    let userName: String?
+    let client: String?
+    let deviceName: String?
+    let nowPlayingItem: String?
+}
+
+struct JellyfinLibrary: Sendable {
+    let id: String
+    let name: String
+    let collectionType: String?
+}
+
+struct JellyfinItemCounts: Sendable {
+    let movieCount: Int
+    let seriesCount: Int
+}
+
+actor JellyfinAPIClient {
+    private let engine: BaseNetworkEngine
+    private var baseURL: String = ""
+    private var fallbackURL: String = ""
+    private var apiKey: String = ""
+
+    init(instanceId: UUID) {
+        self.engine = BaseNetworkEngine(serviceType: .jellyfin, instanceId: instanceId)
+    }
+
+    func configure(url: String, apiKey: String, fallbackUrl: String? = nil) {
+        self.baseURL = Self.cleanURL(url)
+        self.fallbackURL = Self.cleanURL(fallbackUrl ?? "")
+        self.apiKey = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    func ping() async -> Bool {
+        guard !baseURL.isEmpty, !apiKey.isEmpty else { return false }
+        let path = "/System/Info"
+        let primary = await engine.pingURL(baseURL + path, extraHeaders: authHeaders())
+        if primary { return true }
+        guard !fallbackURL.isEmpty else { return false }
+        return await engine.pingURL(fallbackURL + path, extraHeaders: authHeaders())
+    }
+
+    func authenticate(url: String, apiKey: String, fallbackUrl: String? = nil) async throws {
+        let cleanedURL = Self.cleanURL(url)
+        let cleanedFallback = Self.cleanURL(fallbackUrl ?? "")
+        let trimmedKey = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !cleanedURL.isEmpty, !trimmedKey.isEmpty else {
+            throw APIError.notConfigured
+        }
+
+        _ = try await engine.requestData(
+            baseURL: cleanedURL,
+            fallbackURL: cleanedFallback,
+            path: "/System/Info",
+            headers: ["X-Emby-Token": trimmedKey, "Accept": "application/json"]
+        )
+    }
+
+    func getSystemInfo() async throws -> JellyfinSystemInfo {
+        let data = try await engine.requestData(
+            baseURL: baseURL,
+            fallbackURL: fallbackURL,
+            path: "/System/Info",
+            headers: authHeaders()
+        )
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw APIError.decodingError(NSError(domain: "Jellyfin", code: 0, userInfo: [NSLocalizedDescriptionKey: "Invalid JSON"]))
+        }
+        return JellyfinSystemInfo(
+            serverName: stringValue(json["ServerName"]) ?? "Jellyfin",
+            version: stringValue(json["Version"]) ?? "Unknown",
+            operatingSystem: stringValue(json["OperatingSystem"]),
+            hasUpdateAvailable: boolValue(json["HasUpdateAvailable"]) ?? false
+        )
+    }
+
+    func getSessions() async throws -> [JellyfinSession] {
+        let data = try await engine.requestData(
+            baseURL: baseURL,
+            fallbackURL: fallbackURL,
+            path: "/Sessions",
+            headers: authHeaders()
+        )
+        guard let rows = try JSONSerialization.jsonObject(with: data) as? [[String: Any]] else {
+            return []
+        }
+        return rows.compactMap { row in
+            let id = stringValue(row["Id"]) ?? UUID().uuidString
+            let nowPlaying = (row["NowPlayingItem"] as? [String: Any]).flatMap { stringValue($0["Name"]) }
+            return JellyfinSession(
+                id: id,
+                userName: stringValue(row["UserName"]),
+                client: stringValue(row["Client"]),
+                deviceName: stringValue(row["DeviceName"]),
+                nowPlayingItem: nowPlaying
+            )
+        }
+    }
+
+    func getLibraries() async throws -> [JellyfinLibrary] {
+        let data = try await engine.requestData(
+            baseURL: baseURL,
+            fallbackURL: fallbackURL,
+            path: "/Library/MediaFolders",
+            headers: authHeaders()
+        )
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let items = json["Items"] as? [[String: Any]] else {
+            return []
+        }
+        return items.compactMap { item in
+            guard let id = stringValue(item["Id"]) else { return nil }
+            return JellyfinLibrary(
+                id: id,
+                name: stringValue(item["Name"]) ?? "Unknown",
+                collectionType: stringValue(item["CollectionType"])
+            )
+        }
+    }
+
+    func getItemCounts() async throws -> JellyfinItemCounts {
+        let movieData = try await engine.requestData(
+            baseURL: baseURL,
+            fallbackURL: fallbackURL,
+            path: "/Items?Recursive=true&IncludeItemTypes=Movie&Limit=0",
+            headers: authHeaders()
+        )
+        let movieJson = try JSONSerialization.jsonObject(with: movieData) as? [String: Any]
+        let movieCount = intValue(movieJson?["TotalRecordCount"])
+
+        let seriesData = try await engine.requestData(
+            baseURL: baseURL,
+            fallbackURL: fallbackURL,
+            path: "/Items?Recursive=true&IncludeItemTypes=Series&Limit=0",
+            headers: authHeaders()
+        )
+        let seriesJson = try JSONSerialization.jsonObject(with: seriesData) as? [String: Any]
+        let seriesCount = intValue(seriesJson?["TotalRecordCount"])
+
+        return JellyfinItemCounts(movieCount: movieCount, seriesCount: seriesCount)
+    }
+
+    private func authHeaders() -> [String: String] {
+        return [
+            "X-Emby-Token": self.apiKey,
+            "Accept": "application/json"
+        ]
+    }
+
+    private static func cleanURL(_ value: String) -> String {
+        value
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .replacingOccurrences(of: "/+$", with: "", options: .regularExpression)
+    }
+
+    private func stringValue(_ value: Any?) -> String? {
+        guard let text = value as? String else { return nil }
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private func intValue(_ value: Any?) -> Int {
+        if let v = value as? Int { return v }
+        if let v = value as? Double { return Int(v) }
+        if let v = value as? String, let i = Int(v) { return i }
+        return 0
+    }
+
+    private func boolValue(_ value: Any?) -> Bool? {
+        if let v = value as? Bool { return v }
+        if let v = value as? Int { return v != 0 }
+        return nil
+    }
+}

--- a/HomelabSwift/Homelab/Networking/Proxmox/ProxmoxAPIClient.swift
+++ b/HomelabSwift/Homelab/Networking/Proxmox/ProxmoxAPIClient.swift
@@ -1,0 +1,188 @@
+import Foundation
+
+struct ProxmoxNodeInfo: Sendable {
+    let node: String
+    let status: String
+    let cpuUsage: Double
+    let memoryUsed: Int64
+    let memoryTotal: Int64
+    let uptime: Int
+}
+
+struct ProxmoxVM: Sendable {
+    let vmid: Int
+    let name: String
+    let status: String
+    let type: String
+    let node: String
+    let cpuUsage: Double
+    let memoryUsed: Int64
+    let memoryMax: Int64
+}
+
+struct ProxmoxStorage: Sendable {
+    let storage: String
+    let type: String
+    let used: Int64
+    let total: Int64
+    let node: String?
+    let status: String
+}
+
+actor ProxmoxAPIClient {
+    private let engine: BaseNetworkEngine
+    private var baseURL: String = ""
+    private var fallbackURL: String = ""
+    private var apiKey: String = ""
+
+    init(instanceId: UUID) {
+        self.engine = BaseNetworkEngine(serviceType: .proxmox, instanceId: instanceId)
+    }
+
+    func configure(url: String, apiKey: String, fallbackUrl: String? = nil) {
+        self.baseURL = Self.cleanURL(url)
+        self.fallbackURL = Self.cleanURL(fallbackUrl ?? "")
+        self.apiKey = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    func ping() async -> Bool {
+        guard !baseURL.isEmpty, !apiKey.isEmpty else { return false }
+        let path = "/api2/json/version"
+        let primary = await engine.pingURL(baseURL + path, extraHeaders: authHeaders())
+        if primary { return true }
+        guard !fallbackURL.isEmpty else { return false }
+        return await engine.pingURL(fallbackURL + path, extraHeaders: authHeaders())
+    }
+
+    func authenticate(url: String, apiKey: String, fallbackUrl: String? = nil) async throws {
+        let cleanedURL = Self.cleanURL(url)
+        let cleanedFallback = Self.cleanURL(fallbackUrl ?? "")
+        let trimmedKey = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !cleanedURL.isEmpty, !trimmedKey.isEmpty else {
+            throw APIError.notConfigured
+        }
+
+        _ = try await engine.requestData(
+            baseURL: cleanedURL,
+            fallbackURL: cleanedFallback,
+            path: "/api2/json/version",
+            headers: ["Authorization": "PVEAPIToken=\(trimmedKey)", "Accept": "application/json"]
+        )
+    }
+
+    func getNodes() async throws -> [ProxmoxNodeInfo] {
+        let data = try await engine.requestData(
+            baseURL: baseURL,
+            fallbackURL: fallbackURL,
+            path: "/api2/json/nodes",
+            headers: authHeaders()
+        )
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let rows = json["data"] as? [[String: Any]] else {
+            return []
+        }
+        return rows.compactMap { row in
+            guard let node = stringValue(row["node"]) else { return nil }
+            return ProxmoxNodeInfo(
+                node: node,
+                status: stringValue(row["status"]) ?? "unknown",
+                cpuUsage: doubleValue(row["cpu"]),
+                memoryUsed: int64Value(row["mem"]),
+                memoryTotal: int64Value(row["maxmem"]),
+                uptime: intValue(row["uptime"])
+            )
+        }
+    }
+
+    func getVMs() async throws -> [ProxmoxVM] {
+        let data = try await engine.requestData(
+            baseURL: baseURL,
+            fallbackURL: fallbackURL,
+            path: "/api2/json/cluster/resources?type=vm",
+            headers: authHeaders()
+        )
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let rows = json["data"] as? [[String: Any]] else {
+            return []
+        }
+        return rows.compactMap { row in
+            let vmid = intValue(row["vmid"])
+            guard vmid > 0 else { return nil }
+            return ProxmoxVM(
+                vmid: vmid,
+                name: stringValue(row["name"]) ?? "VM \(vmid)",
+                status: stringValue(row["status"]) ?? "unknown",
+                type: stringValue(row["type"]) ?? "qemu",
+                node: stringValue(row["node"]) ?? "unknown",
+                cpuUsage: doubleValue(row["cpu"]),
+                memoryUsed: int64Value(row["mem"]),
+                memoryMax: int64Value(row["maxmem"])
+            )
+        }
+    }
+
+    func getStorages() async throws -> [ProxmoxStorage] {
+        let data = try await engine.requestData(
+            baseURL: baseURL,
+            fallbackURL: fallbackURL,
+            path: "/api2/json/cluster/resources?type=storage",
+            headers: authHeaders()
+        )
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let rows = json["data"] as? [[String: Any]] else {
+            return []
+        }
+        return rows.compactMap { row in
+            guard let storage = stringValue(row["storage"]) else { return nil }
+            return ProxmoxStorage(
+                storage: storage,
+                type: stringValue(row["plugintype"]) ?? stringValue(row["type"]) ?? "unknown",
+                used: int64Value(row["disk"]),
+                total: int64Value(row["maxdisk"]),
+                node: stringValue(row["node"]),
+                status: stringValue(row["status"]) ?? "unknown"
+            )
+        }
+    }
+
+    private func authHeaders() -> [String: String] {
+        return [
+            "Authorization": "PVEAPIToken=\(self.apiKey)",
+            "Accept": "application/json"
+        ]
+    }
+
+    private static func cleanURL(_ value: String) -> String {
+        value
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .replacingOccurrences(of: "/+$", with: "", options: .regularExpression)
+    }
+
+    private func stringValue(_ value: Any?) -> String? {
+        guard let text = value as? String else { return nil }
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private func intValue(_ value: Any?) -> Int {
+        if let v = value as? Int { return v }
+        if let v = value as? Double { return Int(v) }
+        if let v = value as? String, let i = Int(v) { return i }
+        return 0
+    }
+
+    private func int64Value(_ value: Any?) -> Int64 {
+        if let v = value as? Int64 { return v }
+        if let v = value as? Int { return Int64(v) }
+        if let v = value as? Double { return Int64(v) }
+        if let v = value as? String, let i = Int64(v) { return i }
+        return 0
+    }
+
+    private func doubleValue(_ value: Any?) -> Double {
+        if let v = value as? Double { return v }
+        if let v = value as? Int { return Double(v) }
+        if let v = value as? String, let d = Double(v) { return d }
+        return 0
+    }
+}

--- a/HomelabSwift/Homelab/Networking/ProxmoxBackupServer/PBSAPIClient.swift
+++ b/HomelabSwift/Homelab/Networking/ProxmoxBackupServer/PBSAPIClient.swift
@@ -1,0 +1,164 @@
+import Foundation
+
+struct PBSDatastore: Sendable {
+    let name: String
+    let comment: String?
+}
+
+struct PBSDatastoreUsage: Sendable {
+    let store: String
+    let total: Int64
+    let used: Int64
+    let avail: Int64
+}
+
+struct PBSTask: Sendable {
+    let upid: String
+    let worker_type: String
+    let status: String?
+    let startTime: Int?
+    let endTime: Int?
+    let node: String?
+}
+
+actor PBSAPIClient {
+    private let engine: BaseNetworkEngine
+    private var baseURL: String = ""
+    private var fallbackURL: String = ""
+    private var apiKey: String = ""
+
+    init(instanceId: UUID) {
+        self.engine = BaseNetworkEngine(serviceType: .proxmoxBackupServer, instanceId: instanceId)
+    }
+
+    func configure(url: String, apiKey: String, fallbackUrl: String? = nil) {
+        self.baseURL = Self.cleanURL(url)
+        self.fallbackURL = Self.cleanURL(fallbackUrl ?? "")
+        self.apiKey = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    func ping() async -> Bool {
+        guard !baseURL.isEmpty, !apiKey.isEmpty else { return false }
+        let path = "/api2/json/version"
+        let primary = await engine.pingURL(baseURL + path, extraHeaders: authHeaders())
+        if primary { return true }
+        guard !fallbackURL.isEmpty else { return false }
+        return await engine.pingURL(fallbackURL + path, extraHeaders: authHeaders())
+    }
+
+    func authenticate(url: String, apiKey: String, fallbackUrl: String? = nil) async throws {
+        let cleanedURL = Self.cleanURL(url)
+        let cleanedFallback = Self.cleanURL(fallbackUrl ?? "")
+        let trimmedKey = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !cleanedURL.isEmpty, !trimmedKey.isEmpty else {
+            throw APIError.notConfigured
+        }
+
+        _ = try await engine.requestData(
+            baseURL: cleanedURL,
+            fallbackURL: cleanedFallback,
+            path: "/api2/json/version",
+            headers: ["Authorization": "PBSAPIToken=\(trimmedKey)", "Accept": "application/json"]
+        )
+    }
+
+    func getDatastores() async throws -> [PBSDatastore] {
+        let data = try await engine.requestData(
+            baseURL: baseURL,
+            fallbackURL: fallbackURL,
+            path: "/api2/json/admin/datastore",
+            headers: authHeaders()
+        )
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let rows = json["data"] as? [[String: Any]] else {
+            return []
+        }
+        return rows.compactMap { row in
+            guard let name = stringValue(row["name"]) else { return nil }
+            return PBSDatastore(
+                name: name,
+                comment: stringValue(row["comment"])
+            )
+        }
+    }
+
+    func getDatastoreUsage() async throws -> [PBSDatastoreUsage] {
+        let data = try await engine.requestData(
+            baseURL: baseURL,
+            fallbackURL: fallbackURL,
+            path: "/api2/json/status/datastore-usage",
+            headers: authHeaders()
+        )
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let rows = json["data"] as? [[String: Any]] else {
+            return []
+        }
+        return rows.compactMap { row in
+            guard let store = stringValue(row["store"]) else { return nil }
+            return PBSDatastoreUsage(
+                store: store,
+                total: int64Value(row["total"]),
+                used: int64Value(row["used"]),
+                avail: int64Value(row["avail"])
+            )
+        }
+    }
+
+    func getRecentTasks(limit: Int = 10) async throws -> [PBSTask] {
+        let data = try await engine.requestData(
+            baseURL: baseURL,
+            fallbackURL: fallbackURL,
+            path: "/api2/json/nodes/localhost/tasks?limit=\(limit)",
+            headers: authHeaders()
+        )
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let rows = json["data"] as? [[String: Any]] else {
+            return []
+        }
+        return rows.compactMap { row in
+            guard let upid = stringValue(row["upid"]) else { return nil }
+            return PBSTask(
+                upid: upid,
+                worker_type: stringValue(row["worker_type"]) ?? "unknown",
+                status: stringValue(row["status"]),
+                startTime: intValue(row["starttime"]),
+                endTime: intValue(row["endtime"]),
+                node: stringValue(row["node"])
+            )
+        }
+    }
+
+    private func authHeaders() -> [String: String] {
+        return [
+            "Authorization": "PBSAPIToken=\(self.apiKey)",
+            "Accept": "application/json"
+        ]
+    }
+
+    private static func cleanURL(_ value: String) -> String {
+        value
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .replacingOccurrences(of: "/+$", with: "", options: .regularExpression)
+    }
+
+    private func stringValue(_ value: Any?) -> String? {
+        guard let text = value as? String else { return nil }
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private func intValue(_ value: Any?) -> Int? {
+        if let v = value as? Int { return v }
+        if let v = value as? Double { return Int(v) }
+        if let v = value as? String { return Int(v) }
+        return nil
+    }
+
+    private func int64Value(_ value: Any?) -> Int64 {
+        if let v = value as? Int64 { return v }
+        if let v = value as? Int { return Int64(v) }
+        if let v = value as? Double { return Int64(v) }
+        if let v = value as? String, let i = Int64(v) { return i }
+        return 0
+    }
+}

--- a/HomelabSwift/Homelab/Networking/SABnzbd/SABnzbdAPIClient.swift
+++ b/HomelabSwift/Homelab/Networking/SABnzbd/SABnzbdAPIClient.swift
@@ -1,0 +1,148 @@
+import Foundation
+
+struct SABnzbdQueueInfo: Sendable {
+    let status: String
+    let speedBytes: Double
+    let sizeLeft: String
+    let timeLeft: String
+    let totalSlots: Int
+    let mbLeft: Double
+    let diskSpaceFree: String?
+}
+
+struct SABnzbdHistoryEntry: Sendable {
+    let name: String
+    let status: String
+    let size: String
+    let completedAt: String?
+    let category: String?
+}
+
+struct SABnzbdFullStatus: Sendable {
+    let uptime: String?
+    let downloadDir: String?
+    let completeDir: String?
+    let cacheUsed: String?
+}
+
+actor SABnzbdAPIClient {
+    private let engine: BaseNetworkEngine
+    private var baseURL: String = ""
+    private var fallbackURL: String = ""
+    private var apiKey: String = ""
+
+    init(instanceId: UUID) {
+        self.engine = BaseNetworkEngine(serviceType: .sabnzbd, instanceId: instanceId)
+    }
+
+    func configure(url: String, apiKey: String, fallbackUrl: String? = nil) {
+        self.baseURL = Self.cleanURL(url)
+        self.fallbackURL = Self.cleanURL(fallbackUrl ?? "")
+        self.apiKey = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    func ping() async -> Bool {
+        guard !baseURL.isEmpty, !apiKey.isEmpty else { return false }
+        let path = "/api?mode=version&output=json&apikey=\(apiKey)"
+        let primary = await engine.pingURL(baseURL + path)
+        if primary { return true }
+        guard !fallbackURL.isEmpty else { return false }
+        return await engine.pingURL(fallbackURL + path)
+    }
+
+    func authenticate(url: String, apiKey: String, fallbackUrl: String? = nil) async throws {
+        let cleanedURL = Self.cleanURL(url)
+        let cleanedFallback = Self.cleanURL(fallbackUrl ?? "")
+        let trimmedKey = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !cleanedURL.isEmpty, !trimmedKey.isEmpty else {
+            throw APIError.notConfigured
+        }
+
+        _ = try await engine.requestData(
+            baseURL: cleanedURL,
+            fallbackURL: cleanedFallback,
+            path: "/api?mode=version&output=json&apikey=\(trimmedKey)"
+        )
+    }
+
+    func getQueue() async throws -> SABnzbdQueueInfo {
+        let data = try await engine.requestData(
+            baseURL: baseURL,
+            fallbackURL: fallbackURL,
+            path: "/api?mode=queue&output=json&apikey=\(apiKey)"
+        )
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let queue = json["queue"] as? [String: Any] else {
+            throw APIError.decodingError(NSError(domain: "SABnzbd", code: 0, userInfo: [NSLocalizedDescriptionKey: "Invalid JSON"]))
+        }
+        let slots = queue["slots"] as? [[String: Any]] ?? []
+        return SABnzbdQueueInfo(
+            status: stringValue(queue["status"]) ?? "Unknown",
+            speedBytes: doubleValue(queue["kbpersec"]) * 1024,
+            sizeLeft: stringValue(queue["sizeleft"]) ?? "0 B",
+            timeLeft: stringValue(queue["timeleft"]) ?? "0:00:00",
+            totalSlots: slots.count,
+            mbLeft: doubleValue(queue["mbleft"]),
+            diskSpaceFree: stringValue(queue["diskspace1"])
+        )
+    }
+
+    func getHistory(limit: Int = 10) async throws -> [SABnzbdHistoryEntry] {
+        let data = try await engine.requestData(
+            baseURL: baseURL,
+            fallbackURL: fallbackURL,
+            path: "/api?mode=history&output=json&limit=\(limit)&apikey=\(apiKey)"
+        )
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let history = json["history"] as? [String: Any],
+              let slots = history["slots"] as? [[String: Any]] else {
+            return []
+        }
+        return slots.compactMap { slot in
+            SABnzbdHistoryEntry(
+                name: stringValue(slot["name"]) ?? "Unknown",
+                status: stringValue(slot["status"]) ?? "Unknown",
+                size: stringValue(slot["size"]) ?? "0 B",
+                completedAt: stringValue(slot["completed"]),
+                category: stringValue(slot["category"])
+            )
+        }
+    }
+
+    func getFullStatus() async throws -> SABnzbdFullStatus {
+        let data = try await engine.requestData(
+            baseURL: baseURL,
+            fallbackURL: fallbackURL,
+            path: "/api?mode=fullstatus&output=json&apikey=\(apiKey)"
+        )
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let status = json["status"] as? [String: Any] else {
+            throw APIError.decodingError(NSError(domain: "SABnzbd", code: 0, userInfo: [NSLocalizedDescriptionKey: "Invalid JSON"]))
+        }
+        return SABnzbdFullStatus(
+            uptime: stringValue(status["uptime"]),
+            downloadDir: stringValue(status["download_dir"]),
+            completeDir: stringValue(status["complete_dir"]),
+            cacheUsed: stringValue(status["cache_art"])
+        )
+    }
+
+    private static func cleanURL(_ value: String) -> String {
+        value
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .replacingOccurrences(of: "/+$", with: "", options: .regularExpression)
+    }
+
+    private func stringValue(_ value: Any?) -> String? {
+        guard let text = value as? String else { return nil }
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private func doubleValue(_ value: Any?) -> Double {
+        if let v = value as? Double { return v }
+        if let v = value as? Int { return Double(v) }
+        if let v = value as? String, let d = Double(v) { return d }
+        return 0
+    }
+}

--- a/HomelabSwift/Homelab/Networking/Tdarr/TdarrAPIClient.swift
+++ b/HomelabSwift/Homelab/Networking/Tdarr/TdarrAPIClient.swift
@@ -1,0 +1,171 @@
+import Foundation
+
+struct TdarrNode: Identifiable, Sendable {
+    let id: String
+    let name: String
+    let online: Bool
+    let workers: Int
+}
+
+struct TdarrStats: Sendable {
+    let totalFileCount: Int
+    let totalTranscodeCount: Int
+    let totalHealthCheckCount: Int
+    let sizeDiffGB: Double
+    let tdarrScore: String?
+    let healthCheckScore: String?
+    let filesNotInTrash: Int
+}
+
+actor TdarrAPIClient {
+    private let engine: BaseNetworkEngine
+    private var baseURL: String = ""
+    private var fallbackURL: String = ""
+    private var apiKey: String?
+
+    init(instanceId: UUID) {
+        self.engine = BaseNetworkEngine(serviceType: .tdarr, instanceId: instanceId)
+    }
+
+    func configure(url: String, fallbackUrl: String? = nil, apiKey: String? = nil) {
+        self.baseURL = Self.cleanURL(url)
+        self.fallbackURL = Self.cleanURL(fallbackUrl ?? "")
+        self.apiKey = apiKey?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if self.apiKey?.isEmpty == true { self.apiKey = nil }
+    }
+
+    func ping() async -> Bool {
+        guard !baseURL.isEmpty else { return false }
+        do {
+            _ = try await engine.requestData(
+                baseURL: baseURL,
+                fallbackURL: fallbackURL,
+                path: "/api/v2/get-nodes",
+                method: "POST",
+                headers: authHeaders(),
+                body: "{}".data(using: .utf8)
+            )
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    func authenticate(url: String, fallbackUrl: String? = nil, apiKey: String? = nil) async throws {
+        let cleanedURL = Self.cleanURL(url)
+        let cleanedFallback = Self.cleanURL(fallbackUrl ?? "")
+        guard !cleanedURL.isEmpty else {
+            throw APIError.notConfigured
+        }
+
+        var headers = baseHeaders()
+        if let key = apiKey?.trimmingCharacters(in: .whitespacesAndNewlines), !key.isEmpty {
+            headers["x-api-key"] = key
+        }
+
+        _ = try await engine.requestData(
+            baseURL: cleanedURL,
+            fallbackURL: cleanedFallback,
+            path: "/api/v2/get-nodes",
+            method: "POST",
+            headers: headers,
+            body: "{}".data(using: .utf8)
+        )
+    }
+
+    func getNodes() async throws -> [TdarrNode] {
+        let data = try await engine.requestData(
+            baseURL: baseURL,
+            fallbackURL: fallbackURL,
+            path: "/api/v2/get-nodes",
+            method: "POST",
+            headers: authHeaders(),
+            body: "{}".data(using: .utf8)
+        )
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return []
+        }
+        return json.compactMap { key, value in
+            guard let nodeInfo = value as? [String: Any] else { return nil }
+            let name = stringValue(nodeInfo["nodeName"]) ?? key
+            let paused = boolValue(nodeInfo["nodePaused"]) ?? false
+            let workers = intValue(nodeInfo["workers"])
+            return TdarrNode(
+                id: key,
+                name: name,
+                online: !paused,
+                workers: workers
+            )
+        }
+    }
+
+    func getStats() async throws -> TdarrStats {
+        let data = try await engine.requestData(
+            baseURL: baseURL,
+            fallbackURL: fallbackURL,
+            path: "/api/v2/get-stats",
+            method: "POST",
+            headers: authHeaders(),
+            body: "{}".data(using: .utf8)
+        )
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw APIError.decodingError(NSError(domain: "Tdarr", code: 0, userInfo: [NSLocalizedDescriptionKey: "Invalid JSON"]))
+        }
+        return TdarrStats(
+            totalFileCount: intValue(json["totalFileCount"]),
+            totalTranscodeCount: intValue(json["totalTranscodeCount"]),
+            totalHealthCheckCount: intValue(json["totalHealthCheckCount"]),
+            sizeDiffGB: doubleValue(json["sizeDiff"]),
+            tdarrScore: stringValue(json["tdarrScore"]),
+            healthCheckScore: stringValue(json["healthCheckScore"]),
+            filesNotInTrash: intValue(json["filesNotInTrash"])
+        )
+    }
+
+    private func baseHeaders() -> [String: String] {
+        return [
+            "Content-Type": "application/json",
+            "Accept": "application/json"
+        ]
+    }
+
+    private func authHeaders() -> [String: String] {
+        var headers = baseHeaders()
+        if let key = apiKey, !key.isEmpty {
+            headers["x-api-key"] = key
+        }
+        return headers
+    }
+
+    private static func cleanURL(_ value: String) -> String {
+        value
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .replacingOccurrences(of: "/+$", with: "", options: .regularExpression)
+    }
+
+    private func stringValue(_ value: Any?) -> String? {
+        guard let text = value as? String else { return nil }
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private func intValue(_ value: Any?) -> Int {
+        if let v = value as? Int { return v }
+        if let v = value as? Double { return Int(v) }
+        if let v = value as? String, let i = Int(v) { return i }
+        return 0
+    }
+
+    private func doubleValue(_ value: Any?) -> Double {
+        if let v = value as? Double { return v }
+        if let v = value as? Int { return Double(v) }
+        if let v = value as? String, let d = Double(v) { return d }
+        return 0
+    }
+
+    private func boolValue(_ value: Any?) -> Bool? {
+        if let v = value as? Bool { return v }
+        if let v = value as? Int { return v != 0 }
+        return nil
+    }
+}

--- a/HomelabSwift/Homelab/Stores/ServicesStore.swift
+++ b/HomelabSwift/Homelab/Stores/ServicesStore.swift
@@ -21,6 +21,13 @@ private final class ServiceClientManager {
     private var radarrClients: [UUID: RadarrAPIClient] = [:]
     private var sonarrClients: [UUID: SonarrAPIClient] = [:]
     private var lidarrClients: [UUID: LidarrAPIClient] = [:]
+    private var jellyfinClients: [UUID: JellyfinAPIClient] = [:]
+    private var immichClients: [UUID: ImmichAPIClient] = [:]
+    private var grafanaClients: [UUID: GrafanaAPIClient] = [:]
+    private var sabnzbdClients: [UUID: SABnzbdAPIClient] = [:]
+    private var proxmoxClients: [UUID: ProxmoxAPIClient] = [:]
+    private var pbsClients: [UUID: PBSAPIClient] = [:]
+    private var tdarrClients: [UUID: TdarrAPIClient] = [:]
     private var genericClients: [UUID: GenericAPIClient] = [:]
 
     func portainerClient(id: UUID) -> PortainerAPIClient {
@@ -185,6 +192,69 @@ private final class ServiceClientManager {
         return client
     }
     
+    func jellyfinClient(id: UUID) -> JellyfinAPIClient {
+        if let client = jellyfinClients[id] {
+            return client
+        }
+        let client = JellyfinAPIClient(instanceId: id)
+        jellyfinClients[id] = client
+        return client
+    }
+
+    func immichClient(id: UUID) -> ImmichAPIClient {
+        if let client = immichClients[id] {
+            return client
+        }
+        let client = ImmichAPIClient(instanceId: id)
+        immichClients[id] = client
+        return client
+    }
+
+    func grafanaClient(id: UUID) -> GrafanaAPIClient {
+        if let client = grafanaClients[id] {
+            return client
+        }
+        let client = GrafanaAPIClient(instanceId: id)
+        grafanaClients[id] = client
+        return client
+    }
+
+    func sabnzbdClient(id: UUID) -> SABnzbdAPIClient {
+        if let client = sabnzbdClients[id] {
+            return client
+        }
+        let client = SABnzbdAPIClient(instanceId: id)
+        sabnzbdClients[id] = client
+        return client
+    }
+
+    func proxmoxClient(id: UUID) -> ProxmoxAPIClient {
+        if let client = proxmoxClients[id] {
+            return client
+        }
+        let client = ProxmoxAPIClient(instanceId: id)
+        proxmoxClients[id] = client
+        return client
+    }
+
+    func pbsClient(id: UUID) -> PBSAPIClient {
+        if let client = pbsClients[id] {
+            return client
+        }
+        let client = PBSAPIClient(instanceId: id)
+        pbsClients[id] = client
+        return client
+    }
+
+    func tdarrClient(id: UUID) -> TdarrAPIClient {
+        if let client = tdarrClients[id] {
+            return client
+        }
+        let client = TdarrAPIClient(instanceId: id)
+        tdarrClients[id] = client
+        return client
+    }
+
     func genericClient(id: UUID, type: ServiceType) -> GenericAPIClient {
         if let client = genericClients[id] {
             return client
@@ -232,6 +302,20 @@ private final class ServiceClientManager {
             sonarrClients.removeValue(forKey: id)
         case .lidarr:
             lidarrClients.removeValue(forKey: id)
+        case .jellyfin:
+            jellyfinClients.removeValue(forKey: id)
+        case .immich:
+            immichClients.removeValue(forKey: id)
+        case .grafana:
+            grafanaClients.removeValue(forKey: id)
+        case .sabnzbd:
+            sabnzbdClients.removeValue(forKey: id)
+        case .proxmox:
+            proxmoxClients.removeValue(forKey: id)
+        case .proxmoxBackupServer:
+            pbsClients.removeValue(forKey: id)
+        case .tdarr:
+            tdarrClients.removeValue(forKey: id)
         case .jellyseerr, .prowlarr, .bazarr, .gluetun, .flaresolverr:
             genericClients.removeValue(forKey: id)
         }
@@ -520,6 +604,41 @@ final class ServicesStore {
         return clientManager.lidarrClient(id: instance.id)
     }
 
+    func jellyfinClient(instanceId: UUID) async -> JellyfinAPIClient? {
+        guard let instance = instancesById[instanceId], instance.type == .jellyfin else { return nil }
+        return clientManager.jellyfinClient(id: instance.id)
+    }
+
+    func immichClient(instanceId: UUID) async -> ImmichAPIClient? {
+        guard let instance = instancesById[instanceId], instance.type == .immich else { return nil }
+        return clientManager.immichClient(id: instance.id)
+    }
+
+    func grafanaClient(instanceId: UUID) async -> GrafanaAPIClient? {
+        guard let instance = instancesById[instanceId], instance.type == .grafana else { return nil }
+        return clientManager.grafanaClient(id: instance.id)
+    }
+
+    func sabnzbdClient(instanceId: UUID) async -> SABnzbdAPIClient? {
+        guard let instance = instancesById[instanceId], instance.type == .sabnzbd else { return nil }
+        return clientManager.sabnzbdClient(id: instance.id)
+    }
+
+    func proxmoxClient(instanceId: UUID) async -> ProxmoxAPIClient? {
+        guard let instance = instancesById[instanceId], instance.type == .proxmox else { return nil }
+        return clientManager.proxmoxClient(id: instance.id)
+    }
+
+    func pbsClient(instanceId: UUID) async -> PBSAPIClient? {
+        guard let instance = instancesById[instanceId], instance.type == .proxmoxBackupServer else { return nil }
+        return clientManager.pbsClient(id: instance.id)
+    }
+
+    func tdarrClient(instanceId: UUID) async -> TdarrAPIClient? {
+        guard let instance = instancesById[instanceId], instance.type == .tdarr else { return nil }
+        return clientManager.tdarrClient(id: instance.id)
+    }
+
     func genericMediaClient(instanceId: UUID) async -> GenericAPIClient? {
         guard let instance = instancesById[instanceId],
               [.jellyseerr, .prowlarr, .bazarr, .gluetun, .flaresolverr].contains(instance.type) else {
@@ -573,6 +692,20 @@ final class ServicesStore {
             ok = await clientManager.sonarrClient(id: instanceId).ping()
         case .lidarr:
             ok = await clientManager.lidarrClient(id: instanceId).ping()
+        case .jellyfin:
+            ok = await clientManager.jellyfinClient(id: instanceId).ping()
+        case .immich:
+            ok = await clientManager.immichClient(id: instanceId).ping()
+        case .grafana:
+            ok = await clientManager.grafanaClient(id: instanceId).ping()
+        case .sabnzbd:
+            ok = await clientManager.sabnzbdClient(id: instanceId).ping()
+        case .proxmox:
+            ok = await clientManager.proxmoxClient(id: instanceId).ping()
+        case .proxmoxBackupServer:
+            ok = await clientManager.pbsClient(id: instanceId).ping()
+        case .tdarr:
+            ok = await clientManager.tdarrClient(id: instanceId).ping()
         case .jellyseerr, .prowlarr, .bazarr, .gluetun, .flaresolverr:
             ok = await clientManager.genericClient(id: instanceId, type: instance.type).ping()
         }
@@ -898,6 +1031,27 @@ final class ServicesStore {
         case .lidarr:
             let client = clientManager.lidarrClient(id: instance.id)
             await client.configure(url: instance.url, apiKey: instance.apiKey ?? "", fallbackUrl: instance.fallbackUrl)
+        case .jellyfin:
+            let client = clientManager.jellyfinClient(id: instance.id)
+            await client.configure(url: instance.url, apiKey: instance.apiKey ?? "", fallbackUrl: instance.fallbackUrl)
+        case .immich:
+            let client = clientManager.immichClient(id: instance.id)
+            await client.configure(url: instance.url, apiKey: instance.apiKey ?? "", fallbackUrl: instance.fallbackUrl)
+        case .grafana:
+            let client = clientManager.grafanaClient(id: instance.id)
+            await client.configure(url: instance.url, apiKey: instance.apiKey ?? "", fallbackUrl: instance.fallbackUrl)
+        case .sabnzbd:
+            let client = clientManager.sabnzbdClient(id: instance.id)
+            await client.configure(url: instance.url, apiKey: instance.apiKey ?? "", fallbackUrl: instance.fallbackUrl)
+        case .proxmox:
+            let client = clientManager.proxmoxClient(id: instance.id)
+            await client.configure(url: instance.url, apiKey: instance.apiKey ?? "", fallbackUrl: instance.fallbackUrl)
+        case .proxmoxBackupServer:
+            let client = clientManager.pbsClient(id: instance.id)
+            await client.configure(url: instance.url, apiKey: instance.apiKey ?? "", fallbackUrl: instance.fallbackUrl)
+        case .tdarr:
+            let client = clientManager.tdarrClient(id: instance.id)
+            await client.configure(url: instance.url, fallbackUrl: instance.fallbackUrl, apiKey: instance.apiKey)
         case .jellyseerr, .prowlarr, .bazarr, .gluetun, .flaresolverr:
             let client = clientManager.genericClient(id: instance.id, type: instance.type)
             await client.configure(url: instance.url, fallbackUrl: instance.fallbackUrl, apiKey: instance.apiKey)

--- a/HomelabSwift/Homelab/Views/Grafana/GrafanaDashboard.swift
+++ b/HomelabSwift/Homelab/Views/Grafana/GrafanaDashboard.swift
@@ -1,0 +1,197 @@
+import SwiftUI
+
+struct GrafanaDashboard: View {
+    let instanceId: UUID
+
+    @Environment(ServicesStore.self) private var servicesStore
+    @Environment(\.colorScheme) private var colorScheme
+
+    @State private var selectedInstanceId: UUID
+    @State private var state: LoadableState<Void> = .idle
+    @State private var health: GrafanaHealthInfo?
+    @State private var dashboards: [GrafanaDashboardSummary] = []
+    @State private var alerts: [GrafanaAlert] = []
+
+    private let serviceColor = ServiceType.grafana.colors.primary
+
+    init(instanceId: UUID) {
+        self.instanceId = instanceId
+        _selectedInstanceId = State(initialValue: instanceId)
+    }
+
+    var body: some View {
+        ServiceDashboardLayout(
+            serviceType: .grafana,
+            instanceId: selectedInstanceId,
+            state: state,
+            onRefresh: { await load(force: true) }
+        ) {
+            if let health {
+                heroCard(health)
+            }
+
+            statsGrid
+
+            if !alerts.isEmpty {
+                alertsCard
+            }
+
+            if !dashboards.isEmpty {
+                dashboardsCard
+            }
+        }
+        .navigationTitle("Grafana")
+        .task(id: selectedInstanceId) {
+            await load(force: true)
+        }
+    }
+
+    private func heroCard(_ info: GrafanaHealthInfo) -> some View {
+        GlassCard(tint: serviceColor.opacity(colorScheme == .light ? 0.14 : 0.10)) {
+            VStack(alignment: .leading, spacing: 14) {
+                HStack(spacing: 12) {
+                    ServiceIconView(type: .grafana, size: 34)
+                        .frame(width: 56, height: 56)
+                        .background(serviceColor.opacity(0.13), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Grafana")
+                            .font(.headline.bold())
+                            .lineLimit(1)
+                        Text("v\(info.version)")
+                            .font(.caption)
+                            .foregroundStyle(AppTheme.textMuted)
+                    }
+
+                    Spacer()
+                }
+
+                if let db = info.database {
+                    HStack(spacing: 6) {
+                        Image(systemName: "cylinder.fill")
+                            .font(.caption2)
+                            .foregroundStyle(AppTheme.textMuted)
+                        Text("DB: \(db)")
+                            .font(.caption)
+                            .foregroundStyle(AppTheme.textSecondary)
+                    }
+                }
+            }
+            .padding(14)
+        }
+    }
+
+    private var statsGrid: some View {
+        LazyVGrid(columns: twoColumnGrid, spacing: 10) {
+            GlassStatCard(
+                title: "Dashboards",
+                value: "\(dashboards.count)",
+                icon: "square.grid.2x2.fill",
+                iconColor: serviceColor
+            )
+            GlassStatCard(
+                title: "Alerts",
+                value: "\(alerts.count)",
+                icon: "bell.badge.fill",
+                iconColor: alerts.isEmpty ? AppTheme.running : Color(hex: "#EF4444")
+            )
+        }
+    }
+
+    private var alertsCard: some View {
+        GlassCard(tint: AppTheme.surface.opacity(colorScheme == .light ? 0.65 : 0.45)) {
+            VStack(alignment: .leading, spacing: 12) {
+                HStack {
+                    Text("Active Alerts")
+                        .font(.subheadline.weight(.semibold))
+                    Spacer()
+                    Text("\(alerts.count)")
+                        .font(.caption.bold())
+                        .foregroundStyle(Color(hex: "#EF4444"))
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 4)
+                        .background(Color(hex: "#EF4444").opacity(0.14), in: Capsule())
+                }
+
+                ForEach(alerts.prefix(10), id: \.name) { alert in
+                    HStack(spacing: 10) {
+                        Image(systemName: alert.state == "active" ? "exclamationmark.triangle.fill" : "bell.fill")
+                            .font(.caption)
+                            .foregroundStyle(alert.state == "active" ? Color(hex: "#EF4444") : AppTheme.warning)
+
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(alert.name)
+                                .font(.caption.weight(.semibold))
+                                .lineLimit(1)
+                            HStack(spacing: 6) {
+                                Text(alert.state)
+                                    .font(.caption2)
+                                    .foregroundStyle(AppTheme.textMuted)
+                                if let severity = alert.severity {
+                                    Text(severity)
+                                        .font(.caption2)
+                                        .foregroundStyle(AppTheme.textMuted)
+                                }
+                            }
+                        }
+                        Spacer()
+                    }
+                }
+            }
+            .padding(14)
+        }
+    }
+
+    private var dashboardsCard: some View {
+        GlassCard(tint: AppTheme.surface.opacity(colorScheme == .light ? 0.65 : 0.45)) {
+            VStack(alignment: .leading, spacing: 10) {
+                Text("Dashboards")
+                    .font(.subheadline.weight(.semibold))
+
+                ForEach(dashboards.prefix(15), id: \.uid) { dashboard in
+                    HStack(spacing: 10) {
+                        Image(systemName: "chart.bar.xaxis")
+                            .font(.caption)
+                            .foregroundStyle(serviceColor)
+                            .frame(width: 24, height: 24)
+                            .background(serviceColor.opacity(0.12), in: RoundedRectangle(cornerRadius: 6, style: .continuous))
+
+                        Text(dashboard.title)
+                            .font(.caption.weight(.semibold))
+                            .lineLimit(1)
+
+                        Spacer()
+                    }
+                }
+            }
+            .padding(14)
+        }
+    }
+
+    private func load(force: Bool) async {
+        if state.isLoading { return }
+        if case .loaded = state, !force { return }
+
+        state = .loading
+        do {
+            guard let client = await servicesStore.grafanaClient(instanceId: selectedInstanceId) else {
+                state = .error(.notConfigured)
+                return
+            }
+
+            async let healthTask = client.getHealth()
+            async let dashboardsTask = client.getDashboards()
+            async let alertsTask = client.getAlerts()
+
+            health = try await healthTask
+            dashboards = try await dashboardsTask
+            alerts = (try? await alertsTask) ?? []
+
+            state = .loaded(())
+        } catch let apiError as APIError {
+            state = .error(apiError)
+        } catch {
+            state = .error(.custom(error.localizedDescription))
+        }
+    }
+}

--- a/HomelabSwift/Homelab/Views/Home/HomeView.swift
+++ b/HomelabSwift/Homelab/Views/Home/HomeView.swift
@@ -319,6 +319,13 @@ struct HomeView: View {
         case .radarr:            RadarrDashboard(instanceId: route.instanceId)
         case .sonarr:            SonarrDashboard(instanceId: route.instanceId)
         case .lidarr:            LidarrDashboard(instanceId: route.instanceId)
+        case .jellyfin:          JellyfinDashboard(instanceId: route.instanceId)
+        case .immich:            ImmichDashboard(instanceId: route.instanceId)
+        case .grafana:           GrafanaDashboard(instanceId: route.instanceId)
+        case .sabnzbd:           SABnzbdDashboard(instanceId: route.instanceId)
+        case .proxmox:           ProxmoxDashboard(instanceId: route.instanceId)
+        case .proxmoxBackupServer: PBSDashboard(instanceId: route.instanceId)
+        case .tdarr:             TdarrDashboard(instanceId: route.instanceId)
         case .jellyseerr, .prowlarr, .bazarr, .gluetun, .flaresolverr:
                                  GenericMediaDashboard(serviceType: route.type, instanceId: route.instanceId)
         }
@@ -427,6 +434,23 @@ struct HomeView: View {
                 let libs = try await client.getLibraries()
                 let totalItems = libs.reduce(0) { $0 + $1.itemCount + $1.episodeCount }
                 return ServiceSummaryInfo(value: Formatters.formatNumber(totalItems), label: localizer.t.plexTotalItems)
+            case .immich:
+                guard let client = await servicesStore.immichClient(instanceId: instanceId) else { return nil }
+                let assets = try await client.getAssetStatistics()
+                return ServiceSummaryInfo(value: Formatters.formatNumber(assets.total), label: "Total assets")
+            case .grafana:
+                guard let client = await servicesStore.grafanaClient(instanceId: instanceId) else { return nil }
+                let dashboards = try await client.getDashboards()
+                return ServiceSummaryInfo(value: "\(dashboards.count)", label: "Dashboards")
+            case .proxmox:
+                guard let client = await servicesStore.proxmoxClient(instanceId: instanceId) else { return nil }
+                let vms = try await client.getVMs()
+                let running = vms.filter { $0.status == "running" }.count
+                return ServiceSummaryInfo(value: "\(running)", subValue: "/ \(vms.count)", label: "Running guests")
+            case .proxmoxBackupServer:
+                guard let client = await servicesStore.pbsClient(instanceId: instanceId) else { return nil }
+                let datastores = try await client.getDatastores()
+                return ServiceSummaryInfo(value: "\(datastores.count)", label: "Datastores")
             default:
                 return nil
             }

--- a/HomelabSwift/Homelab/Views/Immich/ImmichDashboard.swift
+++ b/HomelabSwift/Homelab/Views/Immich/ImmichDashboard.swift
@@ -1,0 +1,158 @@
+import SwiftUI
+
+struct ImmichDashboard: View {
+    let instanceId: UUID
+
+    @Environment(ServicesStore.self) private var servicesStore
+    @Environment(\.colorScheme) private var colorScheme
+
+    @State private var selectedInstanceId: UUID
+    @State private var state: LoadableState<Void> = .idle
+    @State private var serverInfo: ImmichServerInfo?
+    @State private var statistics: ImmichServerStatistics?
+    @State private var assetStats: ImmichAssetStatistics?
+
+    private let serviceColor = ServiceType.immich.colors.primary
+
+    init(instanceId: UUID) {
+        self.instanceId = instanceId
+        _selectedInstanceId = State(initialValue: instanceId)
+    }
+
+    var body: some View {
+        ServiceDashboardLayout(
+            serviceType: .immich,
+            instanceId: selectedInstanceId,
+            state: state,
+            onRefresh: { await load(force: true) }
+        ) {
+            if let info = serverInfo {
+                heroCard(info)
+            }
+
+            if let assets = assetStats {
+                assetStatsGrid(assets)
+            }
+
+            if let stats = statistics, !stats.usageByUser.isEmpty {
+                usageCard(stats)
+            }
+        }
+        .navigationTitle("Immich")
+        .task(id: selectedInstanceId) {
+            await load(force: true)
+        }
+    }
+
+    private func heroCard(_ info: ImmichServerInfo) -> some View {
+        GlassCard(tint: serviceColor.opacity(colorScheme == .light ? 0.14 : 0.10)) {
+            VStack(alignment: .leading, spacing: 14) {
+                HStack(spacing: 12) {
+                    ServiceIconView(type: .immich, size: 34)
+                        .frame(width: 56, height: 56)
+                        .background(serviceColor.opacity(0.13), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Immich")
+                            .font(.headline.bold())
+                            .lineLimit(1)
+                        Text("v\(info.version)")
+                            .font(.caption)
+                            .foregroundStyle(AppTheme.textMuted)
+                    }
+
+                    Spacer()
+                }
+
+                if let stats = statistics {
+                    HStack(spacing: 6) {
+                        Image(systemName: "externaldrive.fill")
+                            .font(.caption2)
+                            .foregroundStyle(AppTheme.textMuted)
+                        Text(Formatters.formatBytes(Double(stats.totalSize)))
+                            .font(.caption)
+                            .foregroundStyle(AppTheme.textSecondary)
+                    }
+                }
+            }
+            .padding(14)
+        }
+    }
+
+    private func assetStatsGrid(_ assets: ImmichAssetStatistics) -> some View {
+        LazyVGrid(columns: twoColumnGrid, spacing: 10) {
+            GlassStatCard(
+                title: "Photos",
+                value: Formatters.formatNumber(assets.images),
+                icon: "photo.fill",
+                iconColor: serviceColor
+            )
+            GlassStatCard(
+                title: "Videos",
+                value: Formatters.formatNumber(assets.videos),
+                icon: "video.fill",
+                iconColor: Color(hex: "#EC4899")
+            )
+        }
+    }
+
+    private func usageCard(_ stats: ImmichServerStatistics) -> some View {
+        GlassCard(tint: AppTheme.surface.opacity(colorScheme == .light ? 0.65 : 0.45)) {
+            VStack(alignment: .leading, spacing: 12) {
+                Text("Usage by User")
+                    .font(.subheadline.weight(.semibold))
+
+                ForEach(stats.usageByUser, id: \.userName) { user in
+                    HStack(spacing: 10) {
+                        Image(systemName: "person.circle")
+                            .font(.caption)
+                            .foregroundStyle(serviceColor)
+
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(user.userName)
+                                .font(.caption.weight(.semibold))
+                                .lineLimit(1)
+                            Text("\(Formatters.formatNumber(user.photos)) photos, \(Formatters.formatNumber(user.videos)) videos")
+                                .font(.caption2)
+                                .foregroundStyle(AppTheme.textMuted)
+                        }
+
+                        Spacer()
+
+                        Text(Formatters.formatBytes(Double(user.usage)))
+                            .font(.caption2.weight(.semibold))
+                            .foregroundStyle(AppTheme.textSecondary)
+                    }
+                }
+            }
+            .padding(14)
+        }
+    }
+
+    private func load(force: Bool) async {
+        if state.isLoading { return }
+        if case .loaded = state, !force { return }
+
+        state = .loading
+        do {
+            guard let client = await servicesStore.immichClient(instanceId: selectedInstanceId) else {
+                state = .error(.notConfigured)
+                return
+            }
+
+            async let infoTask = client.getServerInfo()
+            async let statsTask = client.getServerStatistics()
+            async let assetTask = client.getAssetStatistics()
+
+            serverInfo = try await infoTask
+            statistics = try await statsTask
+            assetStats = try await assetTask
+
+            state = .loaded(())
+        } catch let apiError as APIError {
+            state = .error(apiError)
+        } catch {
+            state = .error(.custom(error.localizedDescription))
+        }
+    }
+}

--- a/HomelabSwift/Homelab/Views/Jellyfin/JellyfinDashboard.swift
+++ b/HomelabSwift/Homelab/Views/Jellyfin/JellyfinDashboard.swift
@@ -1,0 +1,244 @@
+import SwiftUI
+
+struct JellyfinDashboard: View {
+    let instanceId: UUID
+
+    @Environment(ServicesStore.self) private var servicesStore
+    @Environment(\.colorScheme) private var colorScheme
+
+    @State private var selectedInstanceId: UUID
+    @State private var state: LoadableState<Void> = .idle
+    @State private var systemInfo: JellyfinSystemInfo?
+    @State private var sessions: [JellyfinSession] = []
+    @State private var libraries: [JellyfinLibrary] = []
+    @State private var itemCounts: JellyfinItemCounts?
+
+    private let serviceColor = ServiceType.jellyfin.colors.primary
+
+    init(instanceId: UUID) {
+        self.instanceId = instanceId
+        _selectedInstanceId = State(initialValue: instanceId)
+    }
+
+    var body: some View {
+        ServiceDashboardLayout(
+            serviceType: .jellyfin,
+            instanceId: selectedInstanceId,
+            state: state,
+            onRefresh: { await load(force: true) }
+        ) {
+            if let info = systemInfo {
+                heroCard(info)
+            }
+
+            if !sessions.isEmpty {
+                sessionsCard
+            }
+
+            if let counts = itemCounts {
+                libraryCard(counts)
+            }
+
+            if !libraries.isEmpty {
+                libraryListCard
+            }
+        }
+        .navigationTitle("Jellyfin")
+        .task(id: selectedInstanceId) {
+            await load(force: true)
+        }
+    }
+
+    private func heroCard(_ info: JellyfinSystemInfo) -> some View {
+        GlassCard(tint: serviceColor.opacity(colorScheme == .light ? 0.14 : 0.10)) {
+            VStack(alignment: .leading, spacing: 14) {
+                HStack(spacing: 12) {
+                    ServiceIconView(type: .jellyfin, size: 34)
+                        .frame(width: 56, height: 56)
+                        .background(serviceColor.opacity(0.13), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(info.serverName)
+                            .font(.headline.bold())
+                            .lineLimit(1)
+                        Text("v\(info.version)")
+                            .font(.caption)
+                            .foregroundStyle(AppTheme.textMuted)
+                    }
+
+                    Spacer()
+
+                    if info.hasUpdateAvailable {
+                        Text("Update")
+                            .font(.caption2.bold())
+                            .foregroundStyle(.white)
+                            .padding(.horizontal, 10)
+                            .padding(.vertical, 5)
+                            .background(AppTheme.warning, in: Capsule())
+                    }
+                }
+
+                if let os = info.operatingSystem {
+                    HStack(spacing: 6) {
+                        Image(systemName: "desktopcomputer")
+                            .font(.caption2)
+                            .foregroundStyle(AppTheme.textMuted)
+                        Text(os)
+                            .font(.caption)
+                            .foregroundStyle(AppTheme.textSecondary)
+                    }
+                }
+            }
+            .padding(14)
+        }
+    }
+
+    private var sessionsCard: some View {
+        GlassCard(tint: AppTheme.surface.opacity(colorScheme == .light ? 0.65 : 0.45)) {
+            VStack(alignment: .leading, spacing: 12) {
+                HStack {
+                    Text("Active Sessions")
+                        .font(.subheadline.weight(.semibold))
+                    Spacer()
+                    Text("\(sessions.count)")
+                        .font(.caption.bold())
+                        .foregroundStyle(serviceColor)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 4)
+                        .background(serviceColor.opacity(0.14), in: Capsule())
+                }
+
+                let activeSessions = sessions.filter { $0.nowPlayingItem != nil }
+                let idleSessions = sessions.filter { $0.nowPlayingItem == nil }
+
+                if !activeSessions.isEmpty {
+                    ForEach(activeSessions, id: \.id) { session in
+                        sessionRow(session, isPlaying: true)
+                    }
+                }
+
+                if !idleSessions.isEmpty {
+                    ForEach(idleSessions.prefix(5), id: \.id) { session in
+                        sessionRow(session, isPlaying: false)
+                    }
+                }
+            }
+            .padding(14)
+        }
+    }
+
+    private func sessionRow(_ session: JellyfinSession, isPlaying: Bool) -> some View {
+        HStack(spacing: 10) {
+            Image(systemName: isPlaying ? "play.circle.fill" : "person.circle")
+                .font(.subheadline)
+                .foregroundStyle(isPlaying ? serviceColor : AppTheme.textMuted)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(session.userName ?? "Unknown")
+                    .font(.caption.weight(.semibold))
+                    .lineLimit(1)
+                if let item = session.nowPlayingItem {
+                    Text(item)
+                        .font(.caption2)
+                        .foregroundStyle(serviceColor)
+                        .lineLimit(1)
+                } else {
+                    Text([session.client, session.deviceName].compactMap { $0 }.joined(separator: " - "))
+                        .font(.caption2)
+                        .foregroundStyle(AppTheme.textMuted)
+                        .lineLimit(1)
+                }
+            }
+            Spacer()
+        }
+    }
+
+    private func libraryCard(_ counts: JellyfinItemCounts) -> some View {
+        LazyVGrid(columns: twoColumnGrid, spacing: 10) {
+            GlassStatCard(
+                title: "Movies",
+                value: Formatters.formatNumber(counts.movieCount),
+                icon: "film.fill",
+                iconColor: serviceColor
+            )
+            GlassStatCard(
+                title: "Series",
+                value: Formatters.formatNumber(counts.seriesCount),
+                icon: "tv.fill",
+                iconColor: Color(hex: "#F59E0B")
+            )
+        }
+    }
+
+    private var libraryListCard: some View {
+        GlassCard(tint: AppTheme.surface.opacity(colorScheme == .light ? 0.65 : 0.45)) {
+            VStack(alignment: .leading, spacing: 10) {
+                Text("Libraries")
+                    .font(.subheadline.weight(.semibold))
+
+                ForEach(libraries, id: \.id) { library in
+                    HStack(spacing: 10) {
+                        Image(systemName: iconForCollectionType(library.collectionType))
+                            .font(.caption)
+                            .foregroundStyle(serviceColor)
+                            .frame(width: 24, height: 24)
+                            .background(serviceColor.opacity(0.12), in: RoundedRectangle(cornerRadius: 6, style: .continuous))
+
+                        Text(library.name)
+                            .font(.caption.weight(.semibold))
+                            .lineLimit(1)
+
+                        Spacer()
+
+                        if let type = library.collectionType {
+                            Text(type)
+                                .font(.caption2)
+                                .foregroundStyle(AppTheme.textMuted)
+                        }
+                    }
+                }
+            }
+            .padding(14)
+        }
+    }
+
+    private func iconForCollectionType(_ type: String?) -> String {
+        switch type?.lowercased() {
+        case "movies": return "film.fill"
+        case "tvshows": return "tv.fill"
+        case "music": return "music.note.list"
+        case "books": return "book.fill"
+        case "photos": return "photo.fill"
+        default: return "folder.fill"
+        }
+    }
+
+    private func load(force: Bool) async {
+        if state.isLoading { return }
+        if case .loaded = state, !force { return }
+
+        state = .loading
+        do {
+            guard let client = await servicesStore.jellyfinClient(instanceId: selectedInstanceId) else {
+                state = .error(.notConfigured)
+                return
+            }
+
+            async let infoTask = client.getSystemInfo()
+            async let sessionsTask = client.getSessions()
+            async let librariesTask = client.getLibraries()
+            async let countsTask = client.getItemCounts()
+
+            systemInfo = try await infoTask
+            sessions = try await sessionsTask
+            libraries = try await librariesTask
+            itemCounts = try await countsTask
+
+            state = .loaded(())
+        } catch let apiError as APIError {
+            state = .error(apiError)
+        } catch {
+            state = .error(.custom(error.localizedDescription))
+        }
+    }
+}

--- a/HomelabSwift/Homelab/Views/Media/MediaDashboardView.swift
+++ b/HomelabSwift/Homelab/Views/Media/MediaDashboardView.swift
@@ -99,6 +99,55 @@ struct MediaDashboardView: View {
 
     private func loadCardPreview(for instance: ServiceInstance) async throws -> MediaCardPreviewData {
         switch instance.type {
+        case .jellyfin:
+            guard let client = await servicesStore.jellyfinClient(instanceId: instance.id) else {
+                throw APIError.notConfigured
+            }
+            async let infoTask = client.getSystemInfo()
+            async let sessionsTask = client.getSessions()
+            async let countsTask = client.getItemCounts()
+            let info = try await infoTask
+            let sessions = try await sessionsTask
+            let counts = try await countsTask
+            let activeSessions = sessions.filter { $0.nowPlayingItem != nil }.count
+            return MediaCardPreviewData(
+                headline: "v\(info.version)",
+                metrics: [
+                    MediaCardPreviewMetric(label: arr.statusLabel, value: activeSessions > 0 ? "\(activeSessions) streaming" : "Idle"),
+                    MediaCardPreviewMetric(label: "Movies", value: "\(counts.movieCount)"),
+                    MediaCardPreviewMetric(label: "Series", value: "\(counts.seriesCount)")
+                ]
+            )
+        case .sabnzbd:
+            guard let client = await servicesStore.sabnzbdClient(instanceId: instance.id) else {
+                throw APIError.notConfigured
+            }
+            let queue = try await client.getQueue()
+            return MediaCardPreviewData(
+                headline: queue.status,
+                metrics: [
+                    MediaCardPreviewMetric(label: arr.download, value: "\(Formatters.formatBytes(queue.speedBytes))/s"),
+                    MediaCardPreviewMetric(label: "Queue", value: "\(queue.totalSlots)"),
+                    MediaCardPreviewMetric(label: "Left", value: queue.sizeLeft)
+                ]
+            )
+        case .tdarr:
+            guard let client = await servicesStore.tdarrClient(instanceId: instance.id) else {
+                throw APIError.notConfigured
+            }
+            async let nodesTask = client.getNodes()
+            async let statsTask = client.getStats()
+            let nodes = try await nodesTask
+            let stats = try await statsTask
+            let onlineNodes = nodes.filter { $0.online }.count
+            return MediaCardPreviewData(
+                headline: "\(onlineNodes)/\(nodes.count) nodes",
+                metrics: [
+                    MediaCardPreviewMetric(label: "Files", value: Formatters.formatNumber(stats.totalFileCount)),
+                    MediaCardPreviewMetric(label: "Transcodes", value: Formatters.formatNumber(stats.totalTranscodeCount)),
+                    MediaCardPreviewMetric(label: "Health", value: Formatters.formatNumber(stats.totalHealthCheckCount))
+                ]
+            )
         case .qbittorrent:
             guard let client = await servicesStore.qbittorrentClient(instanceId: instance.id) else {
                 throw APIError.notConfigured
@@ -307,6 +356,8 @@ struct MediaDashboardView: View {
     @ViewBuilder
     private func mediaServiceDestination(for route: MediaServiceRoute) -> some View {
         switch route.type {
+        case .jellyfin:
+            JellyfinDashboard(instanceId: route.instanceId)
         case .qbittorrent:
             QbittorrentDashboard(instanceId: route.instanceId)
         case .radarr:
@@ -315,6 +366,10 @@ struct MediaDashboardView: View {
             SonarrDashboard(instanceId: route.instanceId)
         case .lidarr:
             LidarrDashboard(instanceId: route.instanceId)
+        case .sabnzbd:
+            SABnzbdDashboard(instanceId: route.instanceId)
+        case .tdarr:
+            TdarrDashboard(instanceId: route.instanceId)
         case .jellyseerr, .prowlarr, .bazarr, .gluetun, .flaresolverr:
             GenericMediaDashboard(serviceType: route.type, instanceId: route.instanceId)
         default:

--- a/HomelabSwift/Homelab/Views/Proxmox/ProxmoxDashboard.swift
+++ b/HomelabSwift/Homelab/Views/Proxmox/ProxmoxDashboard.swift
@@ -1,0 +1,250 @@
+import SwiftUI
+
+struct ProxmoxDashboard: View {
+    let instanceId: UUID
+
+    @Environment(ServicesStore.self) private var servicesStore
+    @Environment(\.colorScheme) private var colorScheme
+
+    @State private var selectedInstanceId: UUID
+    @State private var state: LoadableState<Void> = .idle
+    @State private var nodes: [ProxmoxNodeInfo] = []
+    @State private var vms: [ProxmoxVM] = []
+    @State private var storages: [ProxmoxStorage] = []
+
+    private let serviceColor = ServiceType.proxmox.colors.primary
+
+    init(instanceId: UUID) {
+        self.instanceId = instanceId
+        _selectedInstanceId = State(initialValue: instanceId)
+    }
+
+    var body: some View {
+        ServiceDashboardLayout(
+            serviceType: .proxmox,
+            instanceId: selectedInstanceId,
+            state: state,
+            onRefresh: { await load(force: true) }
+        ) {
+            heroCard
+
+            if !nodes.isEmpty {
+                nodesCard
+            }
+
+            statsGrid
+
+            if !vms.isEmpty {
+                vmsCard
+            }
+
+            if !storages.isEmpty {
+                storageCard
+            }
+        }
+        .navigationTitle("Proxmox VE")
+        .task(id: selectedInstanceId) {
+            await load(force: true)
+        }
+    }
+
+    private var heroCard: some View {
+        GlassCard(tint: serviceColor.opacity(colorScheme == .light ? 0.14 : 0.10)) {
+            VStack(alignment: .leading, spacing: 14) {
+                HStack(spacing: 12) {
+                    ServiceIconView(type: .proxmox, size: 34)
+                        .frame(width: 56, height: 56)
+                        .background(serviceColor.opacity(0.13), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Proxmox VE")
+                            .font(.headline.bold())
+                            .lineLimit(1)
+                        Text("\(nodes.count) node\(nodes.count == 1 ? "" : "s")")
+                            .font(.caption)
+                            .foregroundStyle(AppTheme.textMuted)
+                    }
+
+                    Spacer()
+                }
+            }
+            .padding(14)
+        }
+    }
+
+    private var nodesCard: some View {
+        GlassCard(tint: AppTheme.surface.opacity(colorScheme == .light ? 0.65 : 0.45)) {
+            VStack(alignment: .leading, spacing: 12) {
+                Text("Nodes")
+                    .font(.subheadline.weight(.semibold))
+
+                ForEach(nodes, id: \.node) { node in
+                    HStack(spacing: 10) {
+                        Circle()
+                            .fill(node.status == "online" ? AppTheme.running : Color(hex: "#EF4444"))
+                            .frame(width: 8, height: 8)
+
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(node.node)
+                                .font(.caption.weight(.semibold))
+                                .lineLimit(1)
+                            Text("CPU: \(String(format: "%.1f%%", node.cpuUsage * 100)) | RAM: \(Formatters.formatBytes(Double(node.memoryUsed))) / \(Formatters.formatBytes(Double(node.memoryTotal)))")
+                                .font(.caption2)
+                                .foregroundStyle(AppTheme.textMuted)
+                                .lineLimit(1)
+                        }
+
+                        Spacer()
+
+                        Text(formatUptime(node.uptime))
+                            .font(.caption2)
+                            .foregroundStyle(AppTheme.textSecondary)
+                    }
+                }
+            }
+            .padding(14)
+        }
+    }
+
+    private var statsGrid: some View {
+        let running = vms.filter { $0.status == "running" }.count
+        let qemuCount = vms.filter { $0.type == "qemu" }.count
+        let lxcCount = vms.filter { $0.type == "lxc" }.count
+
+        return LazyVGrid(columns: twoColumnGrid, spacing: 10) {
+            GlassStatCard(
+                title: "Running",
+                value: "\(running) / \(vms.count)",
+                icon: "play.circle.fill",
+                iconColor: AppTheme.running
+            )
+            GlassStatCard(
+                title: "VMs / LXCs",
+                value: "\(qemuCount) / \(lxcCount)",
+                icon: "cpu.fill",
+                iconColor: serviceColor
+            )
+        }
+    }
+
+    private var vmsCard: some View {
+        GlassCard(tint: AppTheme.surface.opacity(colorScheme == .light ? 0.65 : 0.45)) {
+            VStack(alignment: .leading, spacing: 12) {
+                HStack {
+                    Text("Guests")
+                        .font(.subheadline.weight(.semibold))
+                    Spacer()
+                    Text("\(vms.count)")
+                        .font(.caption.bold())
+                        .foregroundStyle(serviceColor)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 4)
+                        .background(serviceColor.opacity(0.14), in: Capsule())
+                }
+
+                ForEach(vms.sorted(by: { $0.vmid < $1.vmid }).prefix(20), id: \.vmid) { vm in
+                    HStack(spacing: 10) {
+                        Circle()
+                            .fill(vm.status == "running" ? AppTheme.running : AppTheme.textMuted)
+                            .frame(width: 6, height: 6)
+
+                        VStack(alignment: .leading, spacing: 2) {
+                            HStack(spacing: 4) {
+                                Text(vm.name)
+                                    .font(.caption.weight(.semibold))
+                                    .lineLimit(1)
+                                Text("(\(vm.vmid))")
+                                    .font(.caption2)
+                                    .foregroundStyle(AppTheme.textMuted)
+                            }
+                            Text("\(vm.type.uppercased()) on \(vm.node)")
+                                .font(.caption2)
+                                .foregroundStyle(AppTheme.textMuted)
+                        }
+
+                        Spacer()
+
+                        Text(vm.status)
+                            .font(.caption2.weight(.semibold))
+                            .foregroundStyle(vm.status == "running" ? AppTheme.running : AppTheme.textMuted)
+                    }
+                }
+            }
+            .padding(14)
+        }
+    }
+
+    private var storageCard: some View {
+        GlassCard(tint: AppTheme.surface.opacity(colorScheme == .light ? 0.65 : 0.45)) {
+            VStack(alignment: .leading, spacing: 12) {
+                Text("Storage")
+                    .font(.subheadline.weight(.semibold))
+
+                ForEach(storages, id: \.storage) { storage in
+                    let usagePercent = storage.total > 0 ? Double(storage.used) / Double(storage.total) : 0
+
+                    VStack(spacing: 6) {
+                        HStack {
+                            Text(storage.storage)
+                                .font(.caption.weight(.semibold))
+                                .lineLimit(1)
+                            Spacer()
+                            Text("\(Formatters.formatBytes(Double(storage.used))) / \(Formatters.formatBytes(Double(storage.total)))")
+                                .font(.caption2)
+                                .foregroundStyle(AppTheme.textMuted)
+                        }
+
+                        GeometryReader { geo in
+                            ZStack(alignment: .leading) {
+                                Capsule(style: .continuous)
+                                    .fill(AppTheme.surface.opacity(0.5))
+                                Capsule(style: .continuous)
+                                    .fill(usagePercent > 0.9 ? Color(hex: "#EF4444").gradient : serviceColor.gradient)
+                                    .frame(width: geo.size.width * CGFloat(min(usagePercent, 1.0)))
+                            }
+                        }
+                        .frame(height: 6)
+                    }
+                }
+            }
+            .padding(14)
+        }
+    }
+
+    private func formatUptime(_ seconds: Int) -> String {
+        let days = seconds / 86400
+        let hours = (seconds % 86400) / 3600
+        if days > 0 {
+            return "\(days)d \(hours)h"
+        }
+        let minutes = (seconds % 3600) / 60
+        return "\(hours)h \(minutes)m"
+    }
+
+    private func load(force: Bool) async {
+        if state.isLoading { return }
+        if case .loaded = state, !force { return }
+
+        state = .loading
+        do {
+            guard let client = await servicesStore.proxmoxClient(instanceId: selectedInstanceId) else {
+                state = .error(.notConfigured)
+                return
+            }
+
+            async let nodesTask = client.getNodes()
+            async let vmsTask = client.getVMs()
+            async let storagesTask = client.getStorages()
+
+            nodes = try await nodesTask
+            vms = try await vmsTask
+            storages = try await storagesTask
+
+            state = .loaded(())
+        } catch let apiError as APIError {
+            state = .error(apiError)
+        } catch {
+            state = .error(.custom(error.localizedDescription))
+        }
+    }
+}

--- a/HomelabSwift/Homelab/Views/ProxmoxBackupServer/PBSDashboard.swift
+++ b/HomelabSwift/Homelab/Views/ProxmoxBackupServer/PBSDashboard.swift
@@ -1,0 +1,192 @@
+import SwiftUI
+
+struct PBSDashboard: View {
+    let instanceId: UUID
+
+    @Environment(ServicesStore.self) private var servicesStore
+    @Environment(\.colorScheme) private var colorScheme
+
+    @State private var selectedInstanceId: UUID
+    @State private var state: LoadableState<Void> = .idle
+    @State private var datastores: [PBSDatastore] = []
+    @State private var usage: [PBSDatastoreUsage] = []
+    @State private var tasks: [PBSTask] = []
+
+    private let serviceColor = ServiceType.proxmoxBackupServer.colors.primary
+
+    init(instanceId: UUID) {
+        self.instanceId = instanceId
+        _selectedInstanceId = State(initialValue: instanceId)
+    }
+
+    var body: some View {
+        ServiceDashboardLayout(
+            serviceType: .proxmoxBackupServer,
+            instanceId: selectedInstanceId,
+            state: state,
+            onRefresh: { await load(force: true) }
+        ) {
+            heroCard
+
+            if !usage.isEmpty {
+                usageCard
+            }
+
+            statsGrid
+
+            if !tasks.isEmpty {
+                tasksCard
+            }
+        }
+        .navigationTitle("Proxmox Backup Server")
+        .task(id: selectedInstanceId) {
+            await load(force: true)
+        }
+    }
+
+    private var heroCard: some View {
+        GlassCard(tint: serviceColor.opacity(colorScheme == .light ? 0.14 : 0.10)) {
+            VStack(alignment: .leading, spacing: 14) {
+                HStack(spacing: 12) {
+                    ServiceIconView(type: .proxmoxBackupServer, size: 34)
+                        .frame(width: 56, height: 56)
+                        .background(serviceColor.opacity(0.13), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Proxmox Backup Server")
+                            .font(.headline.bold())
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.8)
+                        Text("\(datastores.count) datastore\(datastores.count == 1 ? "" : "s")")
+                            .font(.caption)
+                            .foregroundStyle(AppTheme.textMuted)
+                    }
+
+                    Spacer()
+                }
+            }
+            .padding(14)
+        }
+    }
+
+    private var usageCard: some View {
+        GlassCard(tint: AppTheme.surface.opacity(colorScheme == .light ? 0.65 : 0.45)) {
+            VStack(alignment: .leading, spacing: 12) {
+                Text("Datastore Usage")
+                    .font(.subheadline.weight(.semibold))
+
+                ForEach(usage, id: \.store) { ds in
+                    let usagePercent = ds.total > 0 ? Double(ds.used) / Double(ds.total) : 0
+
+                    VStack(spacing: 6) {
+                        HStack {
+                            Text(ds.store)
+                                .font(.caption.weight(.semibold))
+                                .lineLimit(1)
+                            Spacer()
+                            Text("\(Formatters.formatBytes(Double(ds.used))) / \(Formatters.formatBytes(Double(ds.total)))")
+                                .font(.caption2)
+                                .foregroundStyle(AppTheme.textMuted)
+                        }
+
+                        GeometryReader { geo in
+                            ZStack(alignment: .leading) {
+                                Capsule(style: .continuous)
+                                    .fill(AppTheme.surface.opacity(0.5))
+                                Capsule(style: .continuous)
+                                    .fill(usagePercent > 0.9 ? Color(hex: "#EF4444").gradient : serviceColor.gradient)
+                                    .frame(width: geo.size.width * CGFloat(min(usagePercent, 1.0)))
+                            }
+                        }
+                        .frame(height: 6)
+                    }
+                }
+            }
+            .padding(14)
+        }
+    }
+
+    private var statsGrid: some View {
+        let okTasks = tasks.filter { $0.status == "OK" || $0.status?.lowercased() == "ok" }.count
+        return LazyVGrid(columns: twoColumnGrid, spacing: 10) {
+            GlassStatCard(
+                title: "Datastores",
+                value: "\(datastores.count)",
+                icon: "externaldrive.fill",
+                iconColor: serviceColor
+            )
+            GlassStatCard(
+                title: "Recent Tasks",
+                value: "\(okTasks) / \(tasks.count)",
+                icon: "checkmark.circle.fill",
+                iconColor: AppTheme.running
+            )
+        }
+    }
+
+    private var tasksCard: some View {
+        GlassCard(tint: AppTheme.surface.opacity(colorScheme == .light ? 0.65 : 0.45)) {
+            VStack(alignment: .leading, spacing: 12) {
+                HStack {
+                    Text("Recent Tasks")
+                        .font(.subheadline.weight(.semibold))
+                    Spacer()
+                    Text("\(tasks.count)")
+                        .font(.caption.bold())
+                        .foregroundStyle(serviceColor)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 4)
+                        .background(serviceColor.opacity(0.14), in: Capsule())
+                }
+
+                ForEach(tasks.prefix(10), id: \.upid) { task in
+                    HStack(spacing: 10) {
+                        let isOk = task.status == "OK" || task.status?.lowercased() == "ok"
+                        Image(systemName: isOk ? "checkmark.circle.fill" : "xmark.circle.fill")
+                            .font(.caption)
+                            .foregroundStyle(isOk ? AppTheme.running : Color(hex: "#EF4444"))
+
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(task.worker_type)
+                                .font(.caption.weight(.semibold))
+                                .lineLimit(1)
+                            Text(task.status ?? "unknown")
+                                .font(.caption2)
+                                .foregroundStyle(AppTheme.textMuted)
+                        }
+
+                        Spacer()
+                    }
+                }
+            }
+            .padding(14)
+        }
+    }
+
+    private func load(force: Bool) async {
+        if state.isLoading { return }
+        if case .loaded = state, !force { return }
+
+        state = .loading
+        do {
+            guard let client = await servicesStore.pbsClient(instanceId: selectedInstanceId) else {
+                state = .error(.notConfigured)
+                return
+            }
+
+            async let datastoresTask = client.getDatastores()
+            async let usageTask = client.getDatastoreUsage()
+            async let tasksTask = client.getRecentTasks(limit: 10)
+
+            datastores = try await datastoresTask
+            usage = try await usageTask
+            tasks = try await tasksTask
+
+            state = .loaded(())
+        } catch let apiError as APIError {
+            state = .error(apiError)
+        } catch {
+            state = .error(.custom(error.localizedDescription))
+        }
+    }
+}

--- a/HomelabSwift/Homelab/Views/SABnzbd/SABnzbdDashboard.swift
+++ b/HomelabSwift/Homelab/Views/SABnzbd/SABnzbdDashboard.swift
@@ -1,0 +1,179 @@
+import SwiftUI
+
+struct SABnzbdDashboard: View {
+    let instanceId: UUID
+
+    @Environment(ServicesStore.self) private var servicesStore
+    @Environment(\.colorScheme) private var colorScheme
+
+    @State private var selectedInstanceId: UUID
+    @State private var state: LoadableState<Void> = .idle
+    @State private var queue: SABnzbdQueueInfo?
+    @State private var history: [SABnzbdHistoryEntry] = []
+
+    private let serviceColor = ServiceType.sabnzbd.colors.primary
+
+    init(instanceId: UUID) {
+        self.instanceId = instanceId
+        _selectedInstanceId = State(initialValue: instanceId)
+    }
+
+    var body: some View {
+        ServiceDashboardLayout(
+            serviceType: .sabnzbd,
+            instanceId: selectedInstanceId,
+            state: state,
+            onRefresh: { await load(force: true) }
+        ) {
+            if let q = queue {
+                heroCard(q)
+                statsGrid(q)
+            }
+
+            if !history.isEmpty {
+                historyCard
+            }
+        }
+        .navigationTitle("SABnzbd")
+        .task(id: selectedInstanceId) {
+            await load(force: true)
+        }
+    }
+
+    private func heroCard(_ q: SABnzbdQueueInfo) -> some View {
+        GlassCard(tint: serviceColor.opacity(colorScheme == .light ? 0.14 : 0.10)) {
+            VStack(alignment: .leading, spacing: 14) {
+                HStack(spacing: 12) {
+                    ServiceIconView(type: .sabnzbd, size: 34)
+                        .frame(width: 56, height: 56)
+                        .background(serviceColor.opacity(0.13), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("SABnzbd")
+                            .font(.headline.bold())
+                            .lineLimit(1)
+                        Text(q.status)
+                            .font(.caption)
+                            .foregroundStyle(q.status.lowercased() == "downloading" ? serviceColor : AppTheme.textMuted)
+                    }
+
+                    Spacer()
+
+                    Text("\(Formatters.formatBytes(q.speedBytes))/s")
+                        .font(.caption.bold())
+                        .foregroundStyle(serviceColor)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 5)
+                        .background(serviceColor.opacity(0.14), in: Capsule())
+                }
+
+                HStack(spacing: 16) {
+                    HStack(spacing: 6) {
+                        Image(systemName: "arrow.down.doc.fill")
+                            .font(.caption2)
+                            .foregroundStyle(AppTheme.textMuted)
+                        Text("\(q.totalSlots) in queue")
+                            .font(.caption)
+                            .foregroundStyle(AppTheme.textSecondary)
+                    }
+
+                    HStack(spacing: 6) {
+                        Image(systemName: "clock")
+                            .font(.caption2)
+                            .foregroundStyle(AppTheme.textMuted)
+                        Text(q.timeLeft)
+                            .font(.caption)
+                            .foregroundStyle(AppTheme.textSecondary)
+                    }
+                }
+            }
+            .padding(14)
+        }
+    }
+
+    private func statsGrid(_ q: SABnzbdQueueInfo) -> some View {
+        LazyVGrid(columns: twoColumnGrid, spacing: 10) {
+            GlassStatCard(
+                title: "Remaining",
+                value: q.sizeLeft,
+                icon: "arrow.down.circle.fill",
+                iconColor: serviceColor
+            )
+            GlassStatCard(
+                title: "Disk Free",
+                value: q.diskSpaceFree ?? "N/A",
+                icon: "internaldrive.fill",
+                iconColor: Color(hex: "#22D3EE")
+            )
+        }
+    }
+
+    private var historyCard: some View {
+        GlassCard(tint: AppTheme.surface.opacity(colorScheme == .light ? 0.65 : 0.45)) {
+            VStack(alignment: .leading, spacing: 12) {
+                HStack {
+                    Text("Recent History")
+                        .font(.subheadline.weight(.semibold))
+                    Spacer()
+                    Text("\(history.count)")
+                        .font(.caption.bold())
+                        .foregroundStyle(serviceColor)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 4)
+                        .background(serviceColor.opacity(0.14), in: Capsule())
+                }
+
+                ForEach(history.prefix(10), id: \.name) { entry in
+                    HStack(spacing: 10) {
+                        Image(systemName: entry.status.lowercased() == "completed" ? "checkmark.circle.fill" : "xmark.circle.fill")
+                            .font(.caption)
+                            .foregroundStyle(entry.status.lowercased() == "completed" ? AppTheme.running : Color(hex: "#EF4444"))
+
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(entry.name)
+                                .font(.caption.weight(.semibold))
+                                .lineLimit(1)
+                            HStack(spacing: 6) {
+                                Text(entry.size)
+                                    .font(.caption2)
+                                    .foregroundStyle(AppTheme.textMuted)
+                                if let cat = entry.category, !cat.isEmpty, cat != "*" {
+                                    Text(cat)
+                                        .font(.caption2)
+                                        .foregroundStyle(AppTheme.textMuted)
+                                }
+                            }
+                        }
+                        Spacer()
+                    }
+                }
+            }
+            .padding(14)
+        }
+    }
+
+    private func load(force: Bool) async {
+        if state.isLoading { return }
+        if case .loaded = state, !force { return }
+
+        state = .loading
+        do {
+            guard let client = await servicesStore.sabnzbdClient(instanceId: selectedInstanceId) else {
+                state = .error(.notConfigured)
+                return
+            }
+
+            async let queueTask = client.getQueue()
+            async let historyTask = client.getHistory(limit: 10)
+
+            queue = try await queueTask
+            history = try await historyTask
+
+            state = .loaded(())
+        } catch let apiError as APIError {
+            state = .error(apiError)
+        } catch {
+            state = .error(.custom(error.localizedDescription))
+        }
+    }
+}

--- a/HomelabSwift/Homelab/Views/ServiceLogin/ServiceLoginView.swift
+++ b/HomelabSwift/Homelab/Views/ServiceLogin/ServiceLoginView.swift
@@ -51,14 +51,20 @@ struct ServiceLoginView: View {
             || serviceType == .jellyseerr
             || serviceType == .prowlarr
             || serviceType == .bazarr
+            || serviceType == .jellyfin
+            || serviceType == .immich
+            || serviceType == .grafana
+            || serviceType == .sabnzbd
+            || serviceType == .proxmox
+            || serviceType == .proxmoxBackupServer
     }
 
     private var supportsCredentiallessAuth: Bool {
-        serviceType == .gluetun || serviceType == .flaresolverr
+        serviceType == .gluetun || serviceType == .flaresolverr || serviceType == .tdarr
     }
 
     private var supportsOptionalApiKey: Bool {
-        serviceType == .gluetun || serviceType == .flaresolverr
+        serviceType == .gluetun || serviceType == .flaresolverr || serviceType == .tdarr
     }
 
     var body: some View {
@@ -303,6 +309,20 @@ struct ServiceLoginView: View {
                                  return localizer.t.loginHintGluetun
         case .flaresolverr:
                                  return localizer.t.loginHintFlaresolverr
+        case .jellyfin:
+                                 return "Enter your Jellyfin server URL and API key. Find the API key in Dashboard > API Keys."
+        case .immich:
+                                 return "Enter your Immich server URL and API key. Generate an API key in Account Settings > API Keys."
+        case .grafana:
+                                 return "Enter your Grafana URL and a Service Account token. Create one in Administration > Service accounts."
+        case .sabnzbd:
+                                 return "Enter your SABnzbd URL and API key. Find the API key in Config > General > Security."
+        case .proxmox:
+                                 return "Enter your Proxmox VE URL and API token. Format: user@realm!tokenid=token-value"
+        case .proxmoxBackupServer:
+                                 return "Enter your PBS URL and API token. Format: user@realm!tokenid=token-value"
+        case .tdarr:
+                                 return "Enter your Tdarr server URL. API key is optional unless server authentication is enabled."
         case .qbittorrent, .radarr, .sonarr, .lidarr, .jellyseerr, .prowlarr, .bazarr:
                                  return nil
         default: return nil
@@ -849,6 +869,122 @@ struct ServiceLoginView: View {
             return ServiceInstance(
                 id: existingInstanceId ?? UUID(),
                 type: genericType,
+                label: label,
+                url: url,
+                token: "",
+                apiKey: key,
+                fallbackUrl: fallbackUrl
+            )
+
+        case .jellyfin:
+            let key = normalizedOptional(apiKey) ?? existingInstance?.apiKey
+            guard let key, !key.isEmpty else {
+                throw APIError.custom(localizer.t.loginErrorCredentials)
+            }
+            let client = JellyfinAPIClient(instanceId: existingInstanceId ?? UUID())
+            try await client.authenticate(url: url, apiKey: key, fallbackUrl: fallbackUrl)
+            return ServiceInstance(
+                id: existingInstanceId ?? UUID(),
+                type: .jellyfin,
+                label: label,
+                url: url,
+                token: "",
+                apiKey: key,
+                fallbackUrl: fallbackUrl
+            )
+
+        case .immich:
+            let key = normalizedOptional(apiKey) ?? existingInstance?.apiKey
+            guard let key, !key.isEmpty else {
+                throw APIError.custom(localizer.t.loginErrorCredentials)
+            }
+            let client = ImmichAPIClient(instanceId: existingInstanceId ?? UUID())
+            try await client.authenticate(url: url, apiKey: key, fallbackUrl: fallbackUrl)
+            return ServiceInstance(
+                id: existingInstanceId ?? UUID(),
+                type: .immich,
+                label: label,
+                url: url,
+                token: "",
+                apiKey: key,
+                fallbackUrl: fallbackUrl
+            )
+
+        case .grafana:
+            let key = normalizedOptional(apiKey) ?? existingInstance?.apiKey
+            guard let key, !key.isEmpty else {
+                throw APIError.custom(localizer.t.loginErrorCredentials)
+            }
+            let client = GrafanaAPIClient(instanceId: existingInstanceId ?? UUID())
+            try await client.authenticate(url: url, apiKey: key, fallbackUrl: fallbackUrl)
+            return ServiceInstance(
+                id: existingInstanceId ?? UUID(),
+                type: .grafana,
+                label: label,
+                url: url,
+                token: "",
+                apiKey: key,
+                fallbackUrl: fallbackUrl
+            )
+
+        case .sabnzbd:
+            let key = normalizedOptional(apiKey) ?? existingInstance?.apiKey
+            guard let key, !key.isEmpty else {
+                throw APIError.custom(localizer.t.loginErrorCredentials)
+            }
+            let client = SABnzbdAPIClient(instanceId: existingInstanceId ?? UUID())
+            try await client.authenticate(url: url, apiKey: key, fallbackUrl: fallbackUrl)
+            return ServiceInstance(
+                id: existingInstanceId ?? UUID(),
+                type: .sabnzbd,
+                label: label,
+                url: url,
+                token: "",
+                apiKey: key,
+                fallbackUrl: fallbackUrl
+            )
+
+        case .proxmox:
+            let key = normalizedOptional(apiKey) ?? existingInstance?.apiKey
+            guard let key, !key.isEmpty else {
+                throw APIError.custom(localizer.t.loginErrorCredentials)
+            }
+            let client = ProxmoxAPIClient(instanceId: existingInstanceId ?? UUID())
+            try await client.authenticate(url: url, apiKey: key, fallbackUrl: fallbackUrl)
+            return ServiceInstance(
+                id: existingInstanceId ?? UUID(),
+                type: .proxmox,
+                label: label,
+                url: url,
+                token: "",
+                apiKey: key,
+                fallbackUrl: fallbackUrl
+            )
+
+        case .proxmoxBackupServer:
+            let key = normalizedOptional(apiKey) ?? existingInstance?.apiKey
+            guard let key, !key.isEmpty else {
+                throw APIError.custom(localizer.t.loginErrorCredentials)
+            }
+            let client = PBSAPIClient(instanceId: existingInstanceId ?? UUID())
+            try await client.authenticate(url: url, apiKey: key, fallbackUrl: fallbackUrl)
+            return ServiceInstance(
+                id: existingInstanceId ?? UUID(),
+                type: .proxmoxBackupServer,
+                label: label,
+                url: url,
+                token: "",
+                apiKey: key,
+                fallbackUrl: fallbackUrl
+            )
+
+        case .tdarr:
+            let key = normalizedOptional(apiKey) ?? existingInstance?.apiKey
+            let client = TdarrAPIClient(instanceId: existingInstanceId ?? UUID())
+            try await client.authenticate(url: url, fallbackUrl: fallbackUrl, apiKey: key)
+            return ServiceInstance(
+                id: existingInstanceId ?? UUID(),
+                type: .tdarr,
                 label: label,
                 url: url,
                 token: "",

--- a/HomelabSwift/Homelab/Views/Tdarr/TdarrDashboard.swift
+++ b/HomelabSwift/Homelab/Views/Tdarr/TdarrDashboard.swift
@@ -1,0 +1,199 @@
+import SwiftUI
+
+struct TdarrDashboard: View {
+    let instanceId: UUID
+
+    @Environment(ServicesStore.self) private var servicesStore
+    @Environment(\.colorScheme) private var colorScheme
+
+    @State private var selectedInstanceId: UUID
+    @State private var state: LoadableState<Void> = .idle
+    @State private var nodes: [TdarrNode] = []
+    @State private var stats: TdarrStats?
+
+    private let serviceColor = ServiceType.tdarr.colors.primary
+
+    init(instanceId: UUID) {
+        self.instanceId = instanceId
+        _selectedInstanceId = State(initialValue: instanceId)
+    }
+
+    var body: some View {
+        ServiceDashboardLayout(
+            serviceType: .tdarr,
+            instanceId: selectedInstanceId,
+            state: state,
+            onRefresh: { await load(force: true) }
+        ) {
+            heroCard
+
+            if let stats {
+                statsGrid(stats)
+                scoresCard(stats)
+            }
+
+            if !nodes.isEmpty {
+                nodesCard
+            }
+        }
+        .navigationTitle("Tdarr")
+        .task(id: selectedInstanceId) {
+            await load(force: true)
+        }
+    }
+
+    private var heroCard: some View {
+        GlassCard(tint: serviceColor.opacity(colorScheme == .light ? 0.14 : 0.10)) {
+            VStack(alignment: .leading, spacing: 14) {
+                HStack(spacing: 12) {
+                    ServiceIconView(type: .tdarr, size: 34)
+                        .frame(width: 56, height: 56)
+                        .background(serviceColor.opacity(0.13), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Tdarr")
+                            .font(.headline.bold())
+                            .lineLimit(1)
+                        Text("\(nodes.count) node\(nodes.count == 1 ? "" : "s")")
+                            .font(.caption)
+                            .foregroundStyle(AppTheme.textMuted)
+                    }
+
+                    Spacer()
+
+                    if let stats, stats.totalFileCount > 0 {
+                        Text("\(Formatters.formatNumber(stats.totalFileCount)) files")
+                            .font(.caption.bold())
+                            .foregroundStyle(serviceColor)
+                            .padding(.horizontal, 10)
+                            .padding(.vertical, 5)
+                            .background(serviceColor.opacity(0.14), in: Capsule())
+                    }
+                }
+
+                if let stats {
+                    HStack(spacing: 6) {
+                        Image(systemName: "arrow.triangle.2.circlepath")
+                            .font(.caption2)
+                            .foregroundStyle(AppTheme.textMuted)
+                        Text("Size diff: \(String(format: "%.1f", stats.sizeDiffGB)) GB")
+                            .font(.caption)
+                            .foregroundStyle(AppTheme.textSecondary)
+                    }
+                }
+            }
+            .padding(14)
+        }
+    }
+
+    private func statsGrid(_ stats: TdarrStats) -> some View {
+        LazyVGrid(columns: twoColumnGrid, spacing: 10) {
+            GlassStatCard(
+                title: "Transcodes",
+                value: Formatters.formatNumber(stats.totalTranscodeCount),
+                icon: "waveform.path",
+                iconColor: serviceColor
+            )
+            GlassStatCard(
+                title: "Health Checks",
+                value: Formatters.formatNumber(stats.totalHealthCheckCount),
+                icon: "heart.text.square.fill",
+                iconColor: Color(hex: "#22D3EE")
+            )
+        }
+    }
+
+    private func scoresCard(_ stats: TdarrStats) -> some View {
+        GlassCard(tint: AppTheme.surface.opacity(colorScheme == .light ? 0.65 : 0.45)) {
+            VStack(alignment: .leading, spacing: 12) {
+                Text("Scores")
+                    .font(.subheadline.weight(.semibold))
+
+                HStack(spacing: 16) {
+                    if let score = stats.tdarrScore {
+                        VStack(spacing: 4) {
+                            Text(score)
+                                .font(.title2.bold())
+                                .foregroundStyle(serviceColor)
+                            Text("Transcode")
+                                .font(.caption2)
+                                .foregroundStyle(AppTheme.textMuted)
+                        }
+                        .frame(maxWidth: .infinity)
+                    }
+
+                    if let score = stats.healthCheckScore {
+                        VStack(spacing: 4) {
+                            Text(score)
+                                .font(.title2.bold())
+                                .foregroundStyle(Color(hex: "#22D3EE"))
+                            Text("Health Check")
+                                .font(.caption2)
+                                .foregroundStyle(AppTheme.textMuted)
+                        }
+                        .frame(maxWidth: .infinity)
+                    }
+                }
+            }
+            .padding(14)
+        }
+    }
+
+    private var nodesCard: some View {
+        GlassCard(tint: AppTheme.surface.opacity(colorScheme == .light ? 0.65 : 0.45)) {
+            VStack(alignment: .leading, spacing: 12) {
+                Text("Nodes")
+                    .font(.subheadline.weight(.semibold))
+
+                ForEach(nodes) { node in
+                    HStack(spacing: 10) {
+                        Circle()
+                            .fill(node.online ? AppTheme.running : AppTheme.textMuted)
+                            .frame(width: 8, height: 8)
+
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(node.name)
+                                .font(.caption.weight(.semibold))
+                                .lineLimit(1)
+                            Text("\(node.workers) worker\(node.workers == 1 ? "" : "s")")
+                                .font(.caption2)
+                                .foregroundStyle(AppTheme.textMuted)
+                        }
+
+                        Spacer()
+
+                        Text(node.online ? "Online" : "Paused")
+                            .font(.caption2.weight(.semibold))
+                            .foregroundStyle(node.online ? AppTheme.running : AppTheme.textMuted)
+                    }
+                }
+            }
+            .padding(14)
+        }
+    }
+
+    private func load(force: Bool) async {
+        if state.isLoading { return }
+        if case .loaded = state, !force { return }
+
+        state = .loading
+        do {
+            guard let client = await servicesStore.tdarrClient(instanceId: selectedInstanceId) else {
+                state = .error(.notConfigured)
+                return
+            }
+
+            async let nodesTask = client.getNodes()
+            async let statsTask = client.getStats()
+
+            nodes = try await nodesTask
+            stats = try await statsTask
+
+            state = .loaded(())
+        } catch let apiError as APIError {
+            state = .error(apiError)
+        } catch {
+            state = .error(.custom(error.localizedDescription))
+        }
+    }
+}


### PR DESCRIPTION
## Summary

adds full ios + android support for 7 new homelab services:

- **jellyfin** - media server dashboard (active streams, library stats, item counts). api key auth via `X-Emby-Token`
- **immich** - photo management (asset stats, storage usage, server info). api key auth via `x-api-key`
- **grafana** - monitoring (alert status, dashboard listing, health check). bearer token auth
- **sabnzbd** - usenet downloader (queue, history, download speed). api key via query param
- **proxmox ve** - hypervisor (node health, vm/lxc status, storage usage). `PVEAPIToken` auth
- **proxmox backup server** - backup status (datastore usage, task history). `PBSAPIToken` auth
- **tdarr** - transcoding manager (node status, queue stats, space savings). credentialless with optional api key

each service follows the existing patterns - dedicated api client, models, dashboard view, login flow, navigation routing, service type registration, and theme colors.

jellyfin, sabnzbd, and tdarr are categorized as media services. immich, grafana, proxmox, and pbs are home services.

## details

- 42 new files, 14 modified files across both platforms
- sabnzbd uses query-param auth (api key appended to url rather than header)
- proxmox/pbs use custom token format (`PVEAPIToken=user@realm!tokenid=secret`)
- proxmox/pbs default to allowing self-signed certs
- tdarr uses credentialless auth pattern (same as gluetun/flaresolverr)
- new service descriptions use hardcoded english strings (matching existing pattern for technitium, linuxUpdate, dockhand)

## test plan

- [ ] ios build succeeds in xcode
- [ ] android build succeeds in android studio
- [ ] each service login flow accepts credentials and pings successfully
- [ ] each dashboard loads and displays data correctly
- [ ] fallback url support works for all new services
- [ ] self-signed cert toggle works for proxmox/pbs