### PR TITLE
feat: add Pterodactyl and Calagopus service integrations

### DIFF
--- a/HomelabAndroid/app/src/main/java/com/homelab/app/data/remote/AuthInterceptor.kt
+++ b/HomelabAndroid/app/src/main/java/com/homelab/app/data/remote/AuthInterceptor.kt
@@ -469,6 +469,12 @@ class AuthInterceptor @Inject constructor(
                     }
                 }
             }
+            ServiceType.PTERODACTYL,
+            ServiceType.CALAGOPUS -> {
+                if (!hasAuthorization && !instance.apiKey.isNullOrBlank()) {
+                    builder.addHeader("Authorization", "Bearer ${instance.apiKey}")
+                }
+            }
             else -> {}
         }
     }

--- a/HomelabAndroid/app/src/main/java/com/homelab/app/data/remote/api/CalagopusApi.kt
+++ b/HomelabAndroid/app/src/main/java/com/homelab/app/data/remote/api/CalagopusApi.kt
@@ -1,0 +1,31 @@
+package com.homelab.app.data.remote.api
+
+import com.homelab.app.data.remote.dto.calagopus.CalagopusPowerRequest
+import com.homelab.app.data.remote.dto.calagopus.CalagopusResourcesResponse
+import com.homelab.app.data.remote.dto.calagopus.CalagopusServerListResponse
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.Header
+import retrofit2.http.POST
+import retrofit2.http.Path
+
+interface CalagopusApi {
+
+    @GET("api/client/servers")
+    suspend fun getServers(
+        @Header("X-Homelab-Instance-Id") instanceId: String
+    ): CalagopusServerListResponse
+
+    @GET("api/client/servers/{uuidShort}/resources")
+    suspend fun getServerResources(
+        @Header("X-Homelab-Instance-Id") instanceId: String,
+        @Path("uuidShort") uuidShort: String
+    ): CalagopusResourcesResponse
+
+    @POST("api/client/servers/{uuidShort}/power")
+    suspend fun sendPowerSignal(
+        @Header("X-Homelab-Instance-Id") instanceId: String,
+        @Path("uuidShort") uuidShort: String,
+        @Body body: CalagopusPowerRequest
+    )
+}

--- a/HomelabAndroid/app/src/main/java/com/homelab/app/data/remote/api/PterodactylApi.kt
+++ b/HomelabAndroid/app/src/main/java/com/homelab/app/data/remote/api/PterodactylApi.kt
@@ -1,0 +1,31 @@
+package com.homelab.app.data.remote.api
+
+import com.homelab.app.data.remote.dto.pterodactyl.PterodactylPowerRequest
+import com.homelab.app.data.remote.dto.pterodactyl.PterodactylResourcesResponse
+import com.homelab.app.data.remote.dto.pterodactyl.PterodactylServerListResponse
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.Header
+import retrofit2.http.POST
+import retrofit2.http.Path
+
+interface PterodactylApi {
+
+    @GET("api/client")
+    suspend fun getServers(
+        @Header("X-Homelab-Instance-Id") instanceId: String
+    ): PterodactylServerListResponse
+
+    @GET("api/client/servers/{identifier}/resources")
+    suspend fun getServerResources(
+        @Header("X-Homelab-Instance-Id") instanceId: String,
+        @Path("identifier") identifier: String
+    ): PterodactylResourcesResponse
+
+    @POST("api/client/servers/{identifier}/power")
+    suspend fun sendPowerSignal(
+        @Header("X-Homelab-Instance-Id") instanceId: String,
+        @Path("identifier") identifier: String,
+        @Body body: PterodactylPowerRequest
+    )
+}

--- a/HomelabAndroid/app/src/main/java/com/homelab/app/data/remote/dto/calagopus/CalagopusDto.kt
+++ b/HomelabAndroid/app/src/main/java/com/homelab/app/data/remote/dto/calagopus/CalagopusDto.kt
@@ -1,0 +1,71 @@
+package com.homelab.app.data.remote.dto.calagopus
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+// ---------- Server List ----------
+
+@Serializable
+data class CalagopusServerListResponse(
+    val servers: CalagopusServerPage
+)
+
+@Serializable
+data class CalagopusServerPage(
+    val total: Int = 0,
+    @SerialName("per_page") val perPage: Int = 0,
+    val page: Int = 0,
+    val data: List<CalagopusServer>
+)
+
+@Serializable
+data class CalagopusServer(
+    val uuid: String,
+    @SerialName("uuid_short") val uuidShort: String,
+    val name: String,
+    val description: String? = null,
+    val status: String? = null,
+    @SerialName("is_suspended") val isSuspended: Boolean = false,
+    @SerialName("server_owner") val isOwner: Boolean = false,
+    @SerialName("node") val nodeName: String? = null,
+    val limits: CalagopusLimits = CalagopusLimits()
+)
+
+@Serializable
+data class CalagopusLimits(
+    val memory: Int = 0,
+    val disk: Int = 0,
+    val cpu: Int = 0,
+    val swap: Int = 0
+)
+
+// ---------- Resources ----------
+
+@Serializable
+data class CalagopusResourcesResponse(
+    val resources: CalagopusResources
+)
+
+@Serializable
+data class CalagopusResources(
+    val state: String = "offline",
+    @SerialName("memory_bytes") val memoryBytes: Long = 0,
+    @SerialName("memory_limit_bytes") val memoryLimitBytes: Long = 0,
+    @SerialName("disk_bytes") val diskBytes: Long = 0,
+    @SerialName("cpu_absolute") val cpuAbsolute: Double = 0.0,
+    val uptime: Long = 0,
+    val network: CalagopusNetwork = CalagopusNetwork()
+)
+
+@Serializable
+data class CalagopusNetwork(
+    @SerialName("rx_bytes") val rxBytes: Long = 0,
+    @SerialName("tx_bytes") val txBytes: Long = 0
+)
+
+// ---------- Power Signal ----------
+
+@Serializable
+data class CalagopusPowerRequest(
+    val signal: String
+)

--- a/HomelabAndroid/app/src/main/java/com/homelab/app/data/remote/dto/pterodactyl/PterodactylDto.kt
+++ b/HomelabAndroid/app/src/main/java/com/homelab/app/data/remote/dto/pterodactyl/PterodactylDto.kt
@@ -1,0 +1,70 @@
+package com.homelab.app.data.remote.dto.pterodactyl
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+// ---------- Server List ----------
+
+@Serializable
+data class PterodactylServerListResponse(
+    val data: List<PterodactylServerWrapper>
+)
+
+@Serializable
+data class PterodactylServerWrapper(
+    val attributes: PterodactylServer
+)
+
+@Serializable
+data class PterodactylServer(
+    val identifier: String,
+    val uuid: String,
+    val name: String,
+    val description: String? = null,
+    @SerialName("is_suspended") val isSuspended: Boolean = false,
+    @SerialName("is_installing") val isInstalling: Boolean = false,
+    val status: String? = null,
+    @SerialName("server_owner") val isOwner: Boolean = false,
+    val node: String? = null,
+    val limits: PterodactylLimits = PterodactylLimits()
+)
+
+@Serializable
+data class PterodactylLimits(
+    val memory: Int = 0,
+    val disk: Int = 0,
+    val cpu: Int = 0,
+    val swap: Int = 0
+)
+
+// ---------- Resources ----------
+
+@Serializable
+data class PterodactylResourcesResponse(
+    val attributes: PterodactylResources
+)
+
+@Serializable
+data class PterodactylResources(
+    @SerialName("current_state") val currentState: String = "offline",
+    @SerialName("is_suspended") val isSuspended: Boolean = false,
+    val resources: PterodactylResourceUsage = PterodactylResourceUsage()
+)
+
+@Serializable
+data class PterodactylResourceUsage(
+    @SerialName("memory_bytes") val memoryBytes: Long = 0,
+    @SerialName("memory_limit_bytes") val memoryLimitBytes: Long = 0,
+    @SerialName("disk_bytes") val diskBytes: Long = 0,
+    @SerialName("cpu_absolute") val cpuAbsolute: Double = 0.0,
+    val uptime: Long = 0,
+    @SerialName("network_rx_bytes") val networkRxBytes: Long = 0,
+    @SerialName("network_tx_bytes") val networkTxBytes: Long = 0
+)
+
+// ---------- Power Signal ----------
+
+@Serializable
+data class PterodactylPowerRequest(
+    val signal: String
+)

--- a/HomelabAndroid/app/src/main/java/com/homelab/app/data/repository/CalagopusRepository.kt
+++ b/HomelabAndroid/app/src/main/java/com/homelab/app/data/repository/CalagopusRepository.kt
@@ -1,0 +1,122 @@
+package com.homelab.app.data.repository
+
+import com.homelab.app.data.remote.TlsClientSelector
+import com.homelab.app.data.remote.api.CalagopusApi
+import com.homelab.app.data.remote.dto.calagopus.CalagopusPowerRequest
+import com.homelab.app.data.remote.dto.calagopus.CalagopusResources
+import com.homelab.app.data.remote.dto.calagopus.CalagopusServer
+import kotlinx.serialization.SerializationException
+import okhttp3.Request
+import retrofit2.HttpException
+import java.io.IOException
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+class CalagopusApiException(
+    val kind: Kind,
+    override val cause: Throwable? = null
+) : Exception(kind.name, cause) {
+    enum class Kind {
+        INVALID_CREDENTIALS,
+        SERVER_ERROR,
+        CONNECTION_ERROR
+    }
+}
+
+@Singleton
+class CalagopusRepository @Inject constructor(
+    private val api: CalagopusApi,
+    private val tlsClientSelector: TlsClientSelector
+) {
+
+    suspend fun authenticate(
+        url: String,
+        apiKey: String,
+        fallbackUrl: String? = null,
+        allowSelfSigned: Boolean = false
+    ) {
+        return withContext(Dispatchers.IO) {
+            val candidates = listOf(url.trim().trimEnd('/'), fallbackUrl?.trim()?.trimEnd('/'))
+                .filterNotNull()
+                .filter { it.isNotBlank() }
+                .distinct()
+
+            var lastError: CalagopusApiException? = null
+            for (baseUrl in candidates) {
+                try {
+                    authenticateAgainst(baseUrl, apiKey, allowSelfSigned)
+                    return@withContext
+                } catch (e: CalagopusApiException) {
+                    lastError = e
+                    if (e.kind == CalagopusApiException.Kind.INVALID_CREDENTIALS) throw e
+                }
+            }
+            throw lastError ?: CalagopusApiException(CalagopusApiException.Kind.CONNECTION_ERROR)
+        }
+    }
+
+    suspend fun getServers(instanceId: String): List<CalagopusServer> {
+        return try {
+            api.getServers(instanceId).servers.data
+        } catch (e: Exception) {
+            throw handleException(e)
+        }
+    }
+
+    suspend fun getServerResources(instanceId: String, uuidShort: String): CalagopusResources {
+        return try {
+            api.getServerResources(instanceId, uuidShort).resources
+        } catch (e: Exception) {
+            throw handleException(e)
+        }
+    }
+
+    suspend fun sendPowerSignal(instanceId: String, uuidShort: String, signal: String) {
+        try {
+            api.sendPowerSignal(instanceId, uuidShort, CalagopusPowerRequest(signal))
+        } catch (e: Exception) {
+            throw handleException(e)
+        }
+    }
+
+    private fun authenticateAgainst(baseUrl: String, apiKey: String, allowSelfSigned: Boolean) {
+        val request = Request.Builder()
+            .url("$baseUrl/api/client/servers")
+            .get()
+            .addHeader("Authorization", "Bearer $apiKey")
+            .addHeader("Accept", "application/json")
+            .build()
+
+        try {
+            tlsClientSelector.forAllowSelfSigned(allowSelfSigned).newCall(request).execute().use { response ->
+                when {
+                    response.code == 401 || response.code == 403 ->
+                        throw CalagopusApiException(CalagopusApiException.Kind.INVALID_CREDENTIALS)
+                    !response.isSuccessful ->
+                        throw CalagopusApiException(CalagopusApiException.Kind.SERVER_ERROR)
+                }
+            }
+        } catch (e: IOException) {
+            throw CalagopusApiException(CalagopusApiException.Kind.CONNECTION_ERROR, e)
+        } catch (e: CalagopusApiException) {
+            throw e
+        } catch (e: Exception) {
+            throw CalagopusApiException(CalagopusApiException.Kind.CONNECTION_ERROR, e)
+        }
+    }
+
+    private fun handleException(e: Throwable): CalagopusApiException {
+        return when (e) {
+            is HttpException -> when (e.code()) {
+                401, 403 -> CalagopusApiException(CalagopusApiException.Kind.INVALID_CREDENTIALS, e)
+                else -> CalagopusApiException(CalagopusApiException.Kind.SERVER_ERROR, e)
+            }
+            is SerializationException -> CalagopusApiException(CalagopusApiException.Kind.SERVER_ERROR, e)
+            is IOException -> CalagopusApiException(CalagopusApiException.Kind.CONNECTION_ERROR, e)
+            is CalagopusApiException -> e
+            else -> CalagopusApiException(CalagopusApiException.Kind.SERVER_ERROR, e)
+        }
+    }
+}

--- a/HomelabAndroid/app/src/main/java/com/homelab/app/data/repository/PterodactylRepository.kt
+++ b/HomelabAndroid/app/src/main/java/com/homelab/app/data/repository/PterodactylRepository.kt
@@ -1,0 +1,131 @@
+package com.homelab.app.data.repository
+
+import com.homelab.app.data.remote.TlsClientSelector
+import com.homelab.app.data.remote.api.PterodactylApi
+import com.homelab.app.data.remote.dto.pterodactyl.PterodactylPowerRequest
+import com.homelab.app.data.remote.dto.pterodactyl.PterodactylResources
+import com.homelab.app.data.remote.dto.pterodactyl.PterodactylServer
+import kotlinx.serialization.json.Json
+import okhttp3.Request
+import retrofit2.HttpException
+import java.io.IOException
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.SerializationException
+
+data class PterodactylDashboardData(
+    val servers: List<PterodactylServer>
+) {
+    val totalServers: Int get() = servers.size
+    val runningServers: Int get() = servers.count { it.status == null && !it.isSuspended && !it.isInstalling }
+}
+
+class PterodactylApiException(
+    val kind: Kind,
+    override val cause: Throwable? = null
+) : Exception(kind.name, cause) {
+    enum class Kind {
+        INVALID_CREDENTIALS,
+        SERVER_ERROR,
+        CONNECTION_ERROR
+    }
+}
+
+@Singleton
+class PterodactylRepository @Inject constructor(
+    private val api: PterodactylApi,
+    private val tlsClientSelector: TlsClientSelector,
+    private val json: Json
+) {
+
+    suspend fun authenticate(
+        url: String,
+        apiKey: String,
+        fallbackUrl: String? = null,
+        allowSelfSigned: Boolean = false
+    ) {
+        return withContext(Dispatchers.IO) {
+            val candidates = listOf(url.trim().trimEnd('/'), fallbackUrl?.trim()?.trimEnd('/'))
+                .filterNotNull()
+                .filter { it.isNotBlank() }
+                .distinct()
+
+            var lastError: PterodactylApiException? = null
+            for (baseUrl in candidates) {
+                try {
+                    authenticateAgainst(baseUrl, apiKey, allowSelfSigned)
+                    return@withContext
+                } catch (error: PterodactylApiException) {
+                    lastError = error
+                    if (error.kind == PterodactylApiException.Kind.INVALID_CREDENTIALS) throw error
+                }
+            }
+            throw lastError ?: PterodactylApiException(PterodactylApiException.Kind.CONNECTION_ERROR)
+        }
+    }
+
+    suspend fun getServers(instanceId: String): List<PterodactylServer> {
+        return try {
+            api.getServers(instanceId).data.map { it.attributes }
+        } catch (e: Exception) {
+            throw handleException(e)
+        }
+    }
+
+    suspend fun getServerResources(instanceId: String, identifier: String): PterodactylResources {
+        return try {
+            api.getServerResources(instanceId, identifier).attributes
+        } catch (e: Exception) {
+            throw handleException(e)
+        }
+    }
+
+    suspend fun sendPowerSignal(instanceId: String, identifier: String, signal: String) {
+        try {
+            api.sendPowerSignal(instanceId, identifier, PterodactylPowerRequest(signal))
+        } catch (e: Exception) {
+            throw handleException(e)
+        }
+    }
+
+    private fun authenticateAgainst(baseUrl: String, apiKey: String, allowSelfSigned: Boolean) {
+        val request = Request.Builder()
+            .url("$baseUrl/api/client")
+            .get()
+            .addHeader("Authorization", "Bearer $apiKey")
+            .addHeader("Accept", "application/json")
+            .build()
+
+        try {
+            tlsClientSelector.forAllowSelfSigned(allowSelfSigned).newCall(request).execute().use { response ->
+                when {
+                    response.code == 401 || response.code == 403 ->
+                        throw PterodactylApiException(PterodactylApiException.Kind.INVALID_CREDENTIALS)
+                    !response.isSuccessful ->
+                        throw PterodactylApiException(PterodactylApiException.Kind.SERVER_ERROR)
+                }
+            }
+        } catch (e: IOException) {
+            throw PterodactylApiException(PterodactylApiException.Kind.CONNECTION_ERROR, e)
+        } catch (e: PterodactylApiException) {
+            throw e
+        } catch (e: Exception) {
+            throw PterodactylApiException(PterodactylApiException.Kind.CONNECTION_ERROR, e)
+        }
+    }
+
+    private fun handleException(e: Throwable): PterodactylApiException {
+        return when (e) {
+            is HttpException -> when (e.code()) {
+                401, 403 -> PterodactylApiException(PterodactylApiException.Kind.INVALID_CREDENTIALS, e)
+                else -> PterodactylApiException(PterodactylApiException.Kind.SERVER_ERROR, e)
+            }
+            is SerializationException -> PterodactylApiException(PterodactylApiException.Kind.SERVER_ERROR, e)
+            is IOException -> PterodactylApiException(PterodactylApiException.Kind.CONNECTION_ERROR, e)
+            is PterodactylApiException -> e
+            else -> PterodactylApiException(PterodactylApiException.Kind.SERVER_ERROR, e)
+        }
+    }
+}

--- a/HomelabAndroid/app/src/main/java/com/homelab/app/di/NetworkModule.kt
+++ b/HomelabAndroid/app/src/main/java/com/homelab/app/di/NetworkModule.kt
@@ -258,4 +258,16 @@ object NetworkModule {
     fun provideProxmoxApi(retrofit: Retrofit): com.homelab.app.data.remote.api.ProxmoxApi {
         return retrofit.create(com.homelab.app.data.remote.api.ProxmoxApi::class.java)
     }
+
+    @Provides
+    @Singleton
+    fun providePterodactylApi(retrofit: Retrofit): com.homelab.app.data.remote.api.PterodactylApi {
+        return retrofit.create(com.homelab.app.data.remote.api.PterodactylApi::class.java)
+    }
+
+    @Provides
+    @Singleton
+    fun provideCalagopusApi(retrofit: Retrofit): com.homelab.app.data.remote.api.CalagopusApi {
+        return retrofit.create(com.homelab.app.data.remote.api.CalagopusApi::class.java)
+    }
 }

--- a/HomelabAndroid/app/src/main/java/com/homelab/app/domain/model/BackupModels.kt
+++ b/HomelabAndroid/app/src/main/java/com/homelab/app/domain/model/BackupModels.kt
@@ -75,6 +75,8 @@ object BackupServiceTypeMapper {
             ServiceType.FLARESOLVERR -> "flaresolverr"
             ServiceType.WAKAPI -> "wakapi"
             ServiceType.PROXMOX -> "proxmox"
+            ServiceType.PTERODACTYL -> "pterodactyl"
+            ServiceType.CALAGOPUS -> "calagopus"
             ServiceType.UNKNOWN -> "unknown"
         }
     }
@@ -114,6 +116,8 @@ object BackupServiceTypeMapper {
             "wakapi" -> ServiceType.WAKAPI
             "crafty_controller", "crafty" -> ServiceType.CRAFTY_CONTROLLER
             "proxmox" -> ServiceType.PROXMOX
+            "pterodactyl" -> ServiceType.PTERODACTYL
+            "calagopus" -> ServiceType.CALAGOPUS
             else -> null
         }
     }

--- a/HomelabAndroid/app/src/main/java/com/homelab/app/ui/backup/BackupScreen.kt
+++ b/HomelabAndroid/app/src/main/java/com/homelab/app/ui/backup/BackupScreen.kt
@@ -687,6 +687,8 @@ private fun backupServiceDisplayName(type: ServiceType): String {
         ServiceType.FLARESOLVERR -> stringResource(R.string.service_flaresolverr)
         ServiceType.WAKAPI -> stringResource(R.string.service_wakapi)
         ServiceType.PROXMOX -> stringResource(R.string.service_proxmox)
+        ServiceType.PTERODACTYL -> stringResource(R.string.service_pterodactyl)
+        ServiceType.CALAGOPUS -> stringResource(R.string.service_calagopus)
         ServiceType.UNKNOWN -> type.displayName
     }
 }

--- a/HomelabAndroid/app/src/main/java/com/homelab/app/ui/calagopus/CalagopusDashboardScreen.kt
+++ b/HomelabAndroid/app/src/main/java/com/homelab/app/ui/calagopus/CalagopusDashboardScreen.kt
@@ -113,7 +113,7 @@ fun CalagopusDashboardScreen(
                 ServiceInstancePicker(
                     instances = instances,
                     selectedInstanceId = viewModel.instanceId,
-                    onInstanceSelected = { onNavigateToInstance(it) },
+                    onInstanceSelected = { onNavigateToInstance(it.id) },
                     modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp)
                 )
             }
@@ -125,7 +125,10 @@ fun CalagopusDashboardScreen(
                     }
                 }
                 is UiState.Error -> {
-                    ErrorScreen(message = s.message, onRetry = s.retryAction)
+                    ErrorScreen(
+                        message = s.message,
+                        onRetry = s.retryAction ?: { viewModel.refresh() }
+                    )
                 }
                 is UiState.Success -> {
                     val servers = s.data

--- a/HomelabAndroid/app/src/main/java/com/homelab/app/ui/calagopus/CalagopusDashboardScreen.kt
+++ b/HomelabAndroid/app/src/main/java/com/homelab/app/ui/calagopus/CalagopusDashboardScreen.kt
@@ -1,0 +1,319 @@
+package com.homelab.app.ui.calagopus
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Circle
+import androidx.compose.material.icons.filled.Memory
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.Speed
+import androidx.compose.material.icons.filled.Storage
+import androidx.compose.material.icons.filled.Timer
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.AssistChipDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.homelab.app.R
+import com.homelab.app.ui.common.ErrorScreen
+import com.homelab.app.ui.components.ServiceInstancePicker
+import com.homelab.app.util.ServiceType
+import com.homelab.app.util.UiState
+import java.util.Locale
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@Composable
+fun CalagopusDashboardScreen(
+    viewModel: CalagopusViewModel = hiltViewModel(),
+    onNavigateBack: () -> Unit,
+    onNavigateToInstance: (String) -> Unit
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val isRefreshing by viewModel.isRefreshing.collectAsStateWithLifecycle()
+    val instances by viewModel.instances.collectAsStateWithLifecycle()
+    val actionServerId by viewModel.actionServerId.collectAsStateWithLifecycle()
+
+    val currentInstance = instances.find { it.id == viewModel.instanceId }
+    val title = currentInstance?.label?.takeIf { it.isNotBlank() } ?: ServiceType.CALAGOPUS.displayName
+
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    LaunchedEffect(viewModel) {
+        viewModel.messages.collect { snackbarHostState.showSnackbar(it) }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        text = title,
+                        style = MaterialTheme.typography.headlineSmall,
+                        fontWeight = FontWeight.Bold,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.back))
+                    }
+                },
+                actions = {
+                    IconButton(onClick = { viewModel.refresh() }) {
+                        Icon(Icons.Default.Refresh, contentDescription = stringResource(R.string.refresh))
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.Transparent)
+            )
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) }
+    ) { paddingValues ->
+        Column(modifier = Modifier.fillMaxSize().padding(paddingValues)) {
+            if (instances.size > 1) {
+                ServiceInstancePicker(
+                    instances = instances,
+                    selectedInstanceId = viewModel.instanceId,
+                    onInstanceSelected = { onNavigateToInstance(it) },
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp)
+                )
+            }
+
+            when (val s = state) {
+                is UiState.Loading -> {
+                    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                        CircularProgressIndicator()
+                    }
+                }
+                is UiState.Error -> {
+                    ErrorScreen(message = s.message, onRetry = s.retryAction)
+                }
+                is UiState.Success -> {
+                    val servers = s.data
+                    if (servers.isEmpty()) {
+                        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                            Text(
+                                text = stringResource(R.string.calagopus_no_servers),
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    } else {
+                        PullToRefreshBox(isRefreshing = isRefreshing, onRefresh = { viewModel.refresh() }) {
+                            LazyColumn(
+                                contentPadding = PaddingValues(16.dp),
+                                verticalArrangement = Arrangement.spacedBy(12.dp)
+                            ) {
+                                items(servers, key = { it.server.uuidShort }) { item ->
+                                    CalagopusServerCard(
+                                        item = item,
+                                        isActionPending = actionServerId == item.server.uuidShort,
+                                        onPowerSignal = { signal ->
+                                            viewModel.sendPowerSignal(item.server.uuidShort, signal)
+                                        }
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+                else -> {}
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun CalagopusServerCard(
+    item: CalagopusServerWithResources,
+    isActionPending: Boolean,
+    onPowerSignal: (String) -> Unit
+) {
+    val server = item.server
+    val res = item.resources
+    val state = res?.state ?: "offline"
+    val isRunning = state == "running"
+    val isStarting = state == "starting"
+    val isStopping = state == "stopping"
+
+    val statusColor = when {
+        server.isSuspended -> MaterialTheme.colorScheme.error
+        isRunning -> Color(0xFF16A34A)
+        isStarting || isStopping -> Color(0xFFF59E0B)
+        else -> MaterialTheme.colorScheme.onSurfaceVariant
+    }
+    val statusLabel = when {
+        server.isSuspended -> stringResource(R.string.calagopus_status_suspended)
+        isRunning -> stringResource(R.string.calagopus_status_running)
+        isStarting -> stringResource(R.string.calagopus_status_starting)
+        isStopping -> stringResource(R.string.calagopus_status_stopping)
+        else -> stringResource(R.string.calagopus_status_offline)
+    }
+
+    ElevatedCard(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    Icons.Default.Circle,
+                    contentDescription = null,
+                    tint = statusColor,
+                    modifier = Modifier.size(10.dp)
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = server.name,
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                    Text(
+                        text = statusLabel,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = statusColor
+                    )
+                }
+                if (isActionPending) {
+                    CircularProgressIndicator(modifier = Modifier.size(24.dp), strokeWidth = 2.dp)
+                }
+            }
+
+            if (res != null && !server.isSuspended) {
+                Spacer(modifier = Modifier.height(10.dp))
+                FlowRow(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalArrangement = Arrangement.spacedBy(4.dp)
+                ) {
+                    ResourceChip(
+                        icon = Icons.Default.Speed,
+                        label = stringResource(R.string.calagopus_cpu),
+                        value = String.format(Locale.getDefault(), "%.1f%%", res.cpuAbsolute)
+                    )
+                    val memMb = res.memoryBytes / 1_048_576.0
+                    ResourceChip(
+                        icon = Icons.Default.Memory,
+                        label = stringResource(R.string.calagopus_ram),
+                        value = String.format(Locale.getDefault(), "%.0f MB", memMb)
+                    )
+                    val diskMb = res.diskBytes / 1_048_576.0
+                    ResourceChip(
+                        icon = Icons.Default.Storage,
+                        label = stringResource(R.string.calagopus_disk),
+                        value = String.format(Locale.getDefault(), "%.0f MB", diskMb)
+                    )
+                    if (res.uptime > 0) {
+                        ResourceChip(
+                            icon = Icons.Default.Timer,
+                            label = stringResource(R.string.calagopus_uptime),
+                            value = formatUptime(res.uptime / 1000L)
+                        )
+                    }
+                }
+            }
+
+            if (!server.isSuspended && !isActionPending) {
+                Spacer(modifier = Modifier.height(10.dp))
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    if (!isRunning && !isStarting) {
+                        OutlinedButton(
+                            onClick = { onPowerSignal("start") },
+                            modifier = Modifier.weight(1f)
+                        ) {
+                            Text(stringResource(R.string.calagopus_action_start))
+                        }
+                    }
+                    if (isRunning || isStarting) {
+                        OutlinedButton(
+                            onClick = { onPowerSignal("restart") },
+                            modifier = Modifier.weight(1f)
+                        ) {
+                            Text(stringResource(R.string.calagopus_action_restart))
+                        }
+                        OutlinedButton(
+                            onClick = { onPowerSignal("stop") },
+                            modifier = Modifier.weight(1f)
+                        ) {
+                            Text(stringResource(R.string.calagopus_action_stop))
+                        }
+                    }
+                    if (isRunning) {
+                        OutlinedButton(
+                            onClick = { onPowerSignal("kill") },
+                            modifier = Modifier.weight(1f)
+                        ) {
+                            Text(stringResource(R.string.calagopus_action_kill))
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ResourceChip(
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    label: String,
+    value: String
+) {
+    AssistChip(
+        onClick = {},
+        label = { Text("$label: $value", style = MaterialTheme.typography.labelSmall) },
+        leadingIcon = { Icon(icon, contentDescription = null, modifier = Modifier.size(14.dp)) },
+        colors = AssistChipDefaults.assistChipColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant
+        )
+    )
+}
+
+private fun formatUptime(seconds: Long): String {
+    val days = seconds / 86400
+    val hours = (seconds % 86400) / 3600
+    val mins = (seconds % 3600) / 60
+    return when {
+        days > 0 -> "${days}d ${hours}h"
+        hours > 0 -> "${hours}h ${mins}m"
+        else -> "${mins}m"
+    }
+}

--- a/HomelabAndroid/app/src/main/java/com/homelab/app/ui/calagopus/CalagopusViewModel.kt
+++ b/HomelabAndroid/app/src/main/java/com/homelab/app/ui/calagopus/CalagopusViewModel.kt
@@ -1,0 +1,138 @@
+package com.homelab.app.ui.calagopus
+
+import android.content.Context
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.homelab.app.data.remote.dto.calagopus.CalagopusResources
+import com.homelab.app.data.remote.dto.calagopus.CalagopusServer
+import com.homelab.app.data.repository.CalagopusRepository
+import com.homelab.app.data.repository.ServicesRepository
+import com.homelab.app.domain.model.ServiceInstance
+import com.homelab.app.util.ErrorHandler
+import com.homelab.app.util.ServiceType
+import com.homelab.app.util.UiState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+data class CalagopusServerWithResources(
+    val server: CalagopusServer,
+    val resources: CalagopusResources?
+)
+
+@HiltViewModel
+class CalagopusViewModel @Inject constructor(
+    private val repository: CalagopusRepository,
+    private val servicesRepository: ServicesRepository,
+    savedStateHandle: SavedStateHandle,
+    @param:ApplicationContext private val context: Context
+) : ViewModel() {
+
+    val instanceId: String = checkNotNull(savedStateHandle["instanceId"])
+
+    private val _uiState = MutableStateFlow<UiState<List<CalagopusServerWithResources>>>(UiState.Loading)
+    val uiState: StateFlow<UiState<List<CalagopusServerWithResources>>> = _uiState.asStateFlow()
+
+    private val _isRefreshing = MutableStateFlow(false)
+    val isRefreshing: StateFlow<Boolean> = _isRefreshing.asStateFlow()
+
+    private val _actionServerId = MutableStateFlow<String?>(null)
+    val actionServerId: StateFlow<String?> = _actionServerId.asStateFlow()
+
+    private val _messages = MutableSharedFlow<String>()
+    val messages: SharedFlow<String> = _messages.asSharedFlow()
+
+    private var refreshJob: Job? = null
+    private var refreshRequestId: Long = 0L
+
+    val instances: StateFlow<List<ServiceInstance>> = servicesRepository.instancesByType
+        .map { it[ServiceType.CALAGOPUS].orEmpty() }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
+    init {
+        refresh(forceLoading = true)
+    }
+
+    fun refresh(forceLoading: Boolean = false) {
+        val requestId = ++refreshRequestId
+        refreshJob?.cancel()
+        refreshJob = viewModelScope.launch {
+            if (forceLoading || _uiState.value !is UiState.Success) {
+                _uiState.value = UiState.Loading
+            }
+            _isRefreshing.value = true
+            try {
+                val servers = repository.getServers(instanceId)
+                val enriched = coroutineScope {
+                    servers.chunked(4).flatMap { chunk ->
+                        chunk.map { server ->
+                            async {
+                                val res = runCatching {
+                                    repository.getServerResources(instanceId, server.uuidShort)
+                                }.getOrNull()
+                                CalagopusServerWithResources(server = server, resources = res)
+                            }
+                        }.awaitAll()
+                    }
+                }
+                _uiState.value = UiState.Success(enriched)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                _uiState.value = UiState.Error(
+                    message = ErrorHandler.getMessage(context, e),
+                    retryAction = { refresh(forceLoading = true) }
+                )
+            } finally {
+                if (requestId == refreshRequestId) {
+                    _isRefreshing.value = false
+                }
+            }
+        }
+    }
+
+    fun sendPowerSignal(uuidShort: String, signal: String) {
+        viewModelScope.launch {
+            _actionServerId.value = uuidShort
+            try {
+                repository.sendPowerSignal(instanceId, uuidShort, signal)
+                _messages.emit(context.getString(com.homelab.app.R.string.calagopus_action_sent))
+                repeat(6) {
+                    delay(1500L)
+                    runCatching {
+                        val updated = repository.getServerResources(instanceId, uuidShort)
+                        val current = _uiState.value
+                        if (current is UiState.Success) {
+                            _uiState.value = UiState.Success(
+                                current.data.map { s ->
+                                    if (s.server.uuidShort == uuidShort) s.copy(resources = updated) else s
+                                }
+                            )
+                        }
+                    }
+                }
+            } catch (e: Exception) {
+                _messages.emit(ErrorHandler.getMessage(context, e))
+            } finally {
+                _actionServerId.value = null
+            }
+        }
+    }
+}

--- a/HomelabAndroid/app/src/main/java/com/homelab/app/ui/home/HomeViewModel.kt
+++ b/HomelabAndroid/app/src/main/java/com/homelab/app/ui/home/HomeViewModel.kt
@@ -19,6 +19,8 @@ import com.homelab.app.data.repository.PatchmonRepository
 import com.homelab.app.data.repository.PangolinRepository
 import com.homelab.app.data.repository.PlexRepository
 import com.homelab.app.data.repository.ProxmoxRepository
+import com.homelab.app.data.repository.PterodactylRepository
+import com.homelab.app.data.repository.CalagopusRepository
 import com.homelab.app.data.repository.AdGuardHomeRepository
 import com.homelab.app.data.repository.PiholeRepository
 import com.homelab.app.data.repository.PortainerRepository
@@ -68,6 +70,8 @@ class HomeViewModel @Inject constructor(
     private val proxmoxRepository: ProxmoxRepository,
     private val pangolinRepository: PangolinRepository,
     private val wakapiRepository: com.homelab.app.data.repository.WakapiRepository,
+    private val pterodactylRepository: PterodactylRepository,
+    private val calagopusRepository: CalagopusRepository,
     private val localPreferencesRepository: LocalPreferencesRepository
 ) : ViewModel() {
 
@@ -363,6 +367,16 @@ class HomeViewModel @Inject constructor(
                     totalRunning += vms.count { it.isRunning } + lxcs.count { it.isRunning }
                 }
                 InstanceSummary("$totalRunning", "/ $totalGuests", "proxmox_guests_running")
+            }
+            ServiceType.PTERODACTYL -> {
+                val servers = pterodactylRepository.getServers(instanceId)
+                val running = servers.count { it.status == null && !it.isSuspended && !it.isInstalling }
+                InstanceSummary("$running", "/ ${servers.size}", "pterodactyl_running_servers")
+            }
+            ServiceType.CALAGOPUS -> {
+                val servers = calagopusRepository.getServers(instanceId)
+                val running = servers.count { it.status == null && !it.isSuspended }
+                InstanceSummary("$running", "/ ${servers.size}", "calagopus_running_servers")
             }
             else -> null
         }

--- a/HomelabAndroid/app/src/main/java/com/homelab/app/ui/login/ServiceLoginScreen.kt
+++ b/HomelabAndroid/app/src/main/java/com/homelab/app/ui/login/ServiceLoginScreen.kt
@@ -239,6 +239,8 @@ fun ServiceLoginScreen(
                 ServiceType.BAZARR -> stringResource(R.string.login_hint_bazarr)
                 ServiceType.GLUETUN -> stringResource(R.string.login_hint_gluetun)
                 ServiceType.FLARESOLVERR -> stringResource(R.string.login_hint_flaresolverr)
+                ServiceType.PTERODACTYL -> stringResource(R.string.login_hint_pterodactyl)
+                ServiceType.CALAGOPUS -> stringResource(R.string.login_hint_calagopus)
                 else -> null
             }
 

--- a/HomelabAndroid/app/src/main/java/com/homelab/app/ui/login/ServiceLoginScreen.kt
+++ b/HomelabAndroid/app/src/main/java/com/homelab/app/ui/login/ServiceLoginScreen.kt
@@ -507,7 +507,9 @@ fun ServiceLoginScreen(
                 serviceType == ServiceType.JELLYSEERR ||
                 serviceType == ServiceType.PROWLARR ||
                 serviceType == ServiceType.BAZARR ||
-                serviceType == ServiceType.WAKAPI
+                serviceType == ServiceType.WAKAPI ||
+                serviceType == ServiceType.PTERODACTYL ||
+                serviceType == ServiceType.CALAGOPUS
             ) {
                 SecretField(
                     value = apiKey,

--- a/HomelabAndroid/app/src/main/java/com/homelab/app/ui/login/ServiceLoginViewModel.kt
+++ b/HomelabAndroid/app/src/main/java/com/homelab/app/ui/login/ServiceLoginViewModel.kt
@@ -30,6 +30,8 @@ import com.homelab.app.data.repository.UnifiRepository
 import com.homelab.app.data.repository.UptimeKumaRepository
 import com.homelab.app.data.repository.WakapiRepository
 import com.homelab.app.data.repository.ProxmoxRepository
+import com.homelab.app.data.repository.PterodactylRepository
+import com.homelab.app.data.repository.CalagopusRepository
 import com.homelab.app.domain.model.PiHoleAuthMode
 import com.homelab.app.domain.model.ServiceInstance
 import com.homelab.app.util.ErrorHandler
@@ -70,7 +72,9 @@ class ServiceLoginViewModel @Inject constructor(
     private val plexRepository: PlexRepository,
     private val mediaArrRepository: MediaArrRepository,
     private val wakapiRepository: WakapiRepository,
-    private val proxmoxRepository: ProxmoxRepository
+    private val proxmoxRepository: ProxmoxRepository,
+    private val pterodactylRepository: PterodactylRepository,
+    private val calagopusRepository: CalagopusRepository
 ) : ViewModel() {
 
     private val existingInstanceId: String? = savedStateHandle["instanceId"]
@@ -681,6 +685,40 @@ class ServiceLoginViewModel @Inject constructor(
                             )
                         }
                         ServiceType.UNKNOWN -> throw IllegalArgumentException(context.getString(R.string.error_unknown))
+                        ServiceType.PTERODACTYL -> {
+                            require(trimmedApiKey.isNotBlank()) { context.getString(R.string.login_error_api_key_required) }
+                            pterodactylRepository.authenticate(
+                                url = cleanUrl,
+                                apiKey = trimmedApiKey,
+                                fallbackUrl = cleanFallbackUrl,
+                                allowSelfSigned = allowSelfSigned
+                            )
+                            ServiceInstance(
+                                id = instanceId,
+                                type = serviceType,
+                                label = normalizedLabel,
+                                url = cleanUrl,
+                                apiKey = trimmedApiKey,
+                                fallbackUrl = cleanFallbackUrl
+                            )
+                        }
+                        ServiceType.CALAGOPUS -> {
+                            require(trimmedApiKey.isNotBlank()) { context.getString(R.string.login_error_api_key_required) }
+                            calagopusRepository.authenticate(
+                                url = cleanUrl,
+                                apiKey = trimmedApiKey,
+                                fallbackUrl = cleanFallbackUrl,
+                                allowSelfSigned = allowSelfSigned
+                            )
+                            ServiceInstance(
+                                id = instanceId,
+                                type = serviceType,
+                                label = normalizedLabel,
+                                url = cleanUrl,
+                                apiKey = trimmedApiKey,
+                                fallbackUrl = cleanFallbackUrl
+                            )
+                        }
                     }
                 }.copy(allowSelfSigned = allowSelfSigned)
 

--- a/HomelabAndroid/app/src/main/java/com/homelab/app/ui/navigation/AppNavigation.kt
+++ b/HomelabAndroid/app/src/main/java/com/homelab/app/ui/navigation/AppNavigation.kt
@@ -99,6 +99,8 @@ private fun dashboardRoute(type: ServiceType, instanceId: String): String {
         ServiceType.WAKAPI -> "wakapi/$instanceId/dashboard"
         ServiceType.PLEX -> "plex/$instanceId/dashboard"
         ServiceType.PROXMOX -> "proxmox/$instanceId/dashboard"
+        ServiceType.PTERODACTYL -> "pterodactyl/$instanceId/dashboard"
+        ServiceType.CALAGOPUS -> "calagopus/$instanceId/dashboard"
         ServiceType.RADARR,
         ServiceType.SONARR,
         ServiceType.LIDARR,
@@ -1342,6 +1344,40 @@ fun AppNavigation() {
                 com.homelab.app.ui.media.MediaServiceDashboardScreen(
                     serviceType = mediaType,
                     onNavigateBack = { navController.popBackStack() }
+                )
+            }
+
+            composable(
+                route = "pterodactyl/{instanceId}/dashboard",
+                arguments = listOf(androidx.navigation.navArgument("instanceId") { type = NavType.StringType })
+            ) { backStackEntry ->
+                val instanceId = backStackEntry.arguments?.getString("instanceId") ?: return@composable
+                com.homelab.app.ui.pterodactyl.PterodactylDashboardScreen(
+                    onNavigateBack = { navController.popBackStack() },
+                    onNavigateToInstance = { newInstanceId ->
+                        if (newInstanceId != instanceId) {
+                            navController.navigate(dashboardRoute(ServiceType.PTERODACTYL, newInstanceId)) {
+                                popUpTo("pterodactyl/$instanceId/dashboard") { inclusive = true }
+                            }
+                        }
+                    }
+                )
+            }
+
+            composable(
+                route = "calagopus/{instanceId}/dashboard",
+                arguments = listOf(androidx.navigation.navArgument("instanceId") { type = NavType.StringType })
+            ) { backStackEntry ->
+                val instanceId = backStackEntry.arguments?.getString("instanceId") ?: return@composable
+                com.homelab.app.ui.calagopus.CalagopusDashboardScreen(
+                    onNavigateBack = { navController.popBackStack() },
+                    onNavigateToInstance = { newInstanceId ->
+                        if (newInstanceId != instanceId) {
+                            navController.navigate(dashboardRoute(ServiceType.CALAGOPUS, newInstanceId)) {
+                                popUpTo("calagopus/$instanceId/dashboard") { inclusive = true }
+                            }
+                        }
+                    }
                 )
             }
         }

--- a/HomelabAndroid/app/src/main/java/com/homelab/app/ui/pterodactyl/PterodactylDashboardScreen.kt
+++ b/HomelabAndroid/app/src/main/java/com/homelab/app/ui/pterodactyl/PterodactylDashboardScreen.kt
@@ -115,7 +115,7 @@ fun PterodactylDashboardScreen(
                 ServiceInstancePicker(
                     instances = instances,
                     selectedInstanceId = viewModel.instanceId,
-                    onInstanceSelected = { onNavigateToInstance(it) },
+                    onInstanceSelected = { onNavigateToInstance(it.id) },
                     modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp)
                 )
             }
@@ -129,7 +129,7 @@ fun PterodactylDashboardScreen(
                 is UiState.Error -> {
                     ErrorScreen(
                         message = s.message,
-                        onRetry = s.retryAction
+                        onRetry = s.retryAction ?: { viewModel.refresh() }
                     )
                 }
                 is UiState.Success -> {

--- a/HomelabAndroid/app/src/main/java/com/homelab/app/ui/pterodactyl/PterodactylDashboardScreen.kt
+++ b/HomelabAndroid/app/src/main/java/com/homelab/app/ui/pterodactyl/PterodactylDashboardScreen.kt
@@ -1,0 +1,327 @@
+package com.homelab.app.ui.pterodactyl
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Circle
+import androidx.compose.material.icons.filled.Memory
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.Speed
+import androidx.compose.material.icons.filled.Storage
+import androidx.compose.material.icons.filled.Timer
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.AssistChipDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.homelab.app.R
+import com.homelab.app.data.remote.dto.pterodactyl.PterodactylResources
+import com.homelab.app.ui.components.ServiceInstancePicker
+import com.homelab.app.ui.common.ErrorScreen
+import com.homelab.app.util.ServiceType
+import com.homelab.app.util.UiState
+import java.util.Locale
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@Composable
+fun PterodactylDashboardScreen(
+    viewModel: PterodactylViewModel = hiltViewModel(),
+    onNavigateBack: () -> Unit,
+    onNavigateToInstance: (String) -> Unit
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val isRefreshing by viewModel.isRefreshing.collectAsStateWithLifecycle()
+    val instances by viewModel.instances.collectAsStateWithLifecycle()
+    val actionServerId by viewModel.actionServerId.collectAsStateWithLifecycle()
+
+    val currentInstance = instances.find { it.id == viewModel.instanceId }
+    val title = currentInstance?.label?.takeIf { it.isNotBlank() } ?: ServiceType.PTERODACTYL.displayName
+
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    LaunchedEffect(viewModel) {
+        viewModel.messages.collect { snackbarHostState.showSnackbar(it) }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        text = title,
+                        style = MaterialTheme.typography.headlineSmall,
+                        fontWeight = FontWeight.Bold,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.back))
+                    }
+                },
+                actions = {
+                    IconButton(onClick = { viewModel.refresh() }) {
+                        Icon(Icons.Default.Refresh, contentDescription = stringResource(R.string.refresh))
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.Transparent)
+            )
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) }
+    ) { paddingValues ->
+        Column(modifier = Modifier.fillMaxSize().padding(paddingValues)) {
+            if (instances.size > 1) {
+                ServiceInstancePicker(
+                    instances = instances,
+                    selectedInstanceId = viewModel.instanceId,
+                    onInstanceSelected = { onNavigateToInstance(it) },
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp)
+                )
+            }
+
+            when (val s = state) {
+                is UiState.Loading -> {
+                    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                        CircularProgressIndicator()
+                    }
+                }
+                is UiState.Error -> {
+                    ErrorScreen(
+                        message = s.message,
+                        onRetry = s.retryAction
+                    )
+                }
+                is UiState.Success -> {
+                    val servers = s.data
+                    if (servers.isEmpty()) {
+                        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                            Text(
+                                text = stringResource(R.string.pterodactyl_no_servers),
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    } else {
+                        PullToRefreshBox(isRefreshing = isRefreshing, onRefresh = { viewModel.refresh() }) {
+                            LazyColumn(
+                                contentPadding = PaddingValues(16.dp),
+                                verticalArrangement = Arrangement.spacedBy(12.dp)
+                            ) {
+                                items(servers, key = { it.server.identifier }) { item ->
+                                    PterodactylServerCard(
+                                        item = item,
+                                        isActionPending = actionServerId == item.server.identifier,
+                                        onPowerSignal = { signal ->
+                                            viewModel.sendPowerSignal(item.server.identifier, signal)
+                                        }
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+                else -> {}
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun PterodactylServerCard(
+    item: PterodactylServerWithResources,
+    isActionPending: Boolean,
+    onPowerSignal: (String) -> Unit
+) {
+    val server = item.server
+    val res = item.resources
+    val state = res?.currentState ?: "offline"
+    val isRunning = state == "running"
+    val isStarting = state == "starting"
+    val isStopping = state == "stopping"
+
+    val statusColor = when {
+        server.isSuspended -> MaterialTheme.colorScheme.error
+        server.isInstalling -> MaterialTheme.colorScheme.secondary
+        isRunning -> Color(0xFF16A34A)
+        isStarting || isStopping -> Color(0xFFF59E0B)
+        else -> MaterialTheme.colorScheme.onSurfaceVariant
+    }
+    val statusLabel = when {
+        server.isSuspended -> stringResource(R.string.pterodactyl_status_suspended)
+        server.isInstalling -> stringResource(R.string.pterodactyl_status_installing)
+        isRunning -> stringResource(R.string.pterodactyl_status_running)
+        isStarting -> stringResource(R.string.pterodactyl_status_starting)
+        isStopping -> stringResource(R.string.pterodactyl_status_stopping)
+        else -> stringResource(R.string.pterodactyl_status_offline)
+    }
+
+    ElevatedCard(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    Icons.Default.Circle,
+                    contentDescription = null,
+                    tint = statusColor,
+                    modifier = Modifier.size(10.dp)
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = server.name,
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                    Text(
+                        text = statusLabel,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = statusColor
+                    )
+                }
+                if (isActionPending) {
+                    CircularProgressIndicator(modifier = Modifier.size(24.dp), strokeWidth = 2.dp)
+                }
+            }
+
+            if (res != null && !server.isSuspended) {
+                Spacer(modifier = Modifier.height(10.dp))
+                FlowRow(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalArrangement = Arrangement.spacedBy(4.dp)
+                ) {
+                    ResourceChip(
+                        icon = Icons.Default.Speed,
+                        label = stringResource(R.string.pterodactyl_cpu),
+                        value = String.format(Locale.getDefault(), "%.1f%%", res.resources.cpuAbsolute)
+                    )
+                    val memMb = res.resources.memoryBytes / 1_048_576.0
+                    ResourceChip(
+                        icon = Icons.Default.Memory,
+                        label = stringResource(R.string.pterodactyl_ram),
+                        value = String.format(Locale.getDefault(), "%.0f MB", memMb)
+                    )
+                    val diskMb = res.resources.diskBytes / 1_048_576.0
+                    ResourceChip(
+                        icon = Icons.Default.Storage,
+                        label = stringResource(R.string.pterodactyl_disk),
+                        value = String.format(Locale.getDefault(), "%.0f MB", diskMb)
+                    )
+                    val uptimeSecs = res.resources.uptime / 1000L
+                    if (uptimeSecs > 0) {
+                        ResourceChip(
+                            icon = Icons.Default.Timer,
+                            label = stringResource(R.string.pterodactyl_uptime),
+                            value = formatUptime(uptimeSecs)
+                        )
+                    }
+                }
+            }
+
+            if (!server.isSuspended && !isActionPending) {
+                Spacer(modifier = Modifier.height(10.dp))
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    if (!isRunning && !isStarting) {
+                        OutlinedButton(
+                            onClick = { onPowerSignal("start") },
+                            modifier = Modifier.weight(1f)
+                        ) {
+                            Text(stringResource(R.string.pterodactyl_action_start))
+                        }
+                    }
+                    if (isRunning || isStarting) {
+                        OutlinedButton(
+                            onClick = { onPowerSignal("restart") },
+                            modifier = Modifier.weight(1f)
+                        ) {
+                            Text(stringResource(R.string.pterodactyl_action_restart))
+                        }
+                        OutlinedButton(
+                            onClick = { onPowerSignal("stop") },
+                            modifier = Modifier.weight(1f)
+                        ) {
+                            Text(stringResource(R.string.pterodactyl_action_stop))
+                        }
+                    }
+                    if (isRunning) {
+                        OutlinedButton(
+                            onClick = { onPowerSignal("kill") },
+                            modifier = Modifier.weight(1f)
+                        ) {
+                            Text(stringResource(R.string.pterodactyl_action_kill))
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ResourceChip(
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    label: String,
+    value: String
+) {
+    AssistChip(
+        onClick = {},
+        label = { Text("$label: $value", style = MaterialTheme.typography.labelSmall) },
+        leadingIcon = { Icon(icon, contentDescription = null, modifier = Modifier.size(14.dp)) },
+        colors = AssistChipDefaults.assistChipColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant
+        )
+    )
+}
+
+private fun formatUptime(seconds: Long): String {
+    val days = seconds / 86400
+    val hours = (seconds % 86400) / 3600
+    val mins = (seconds % 3600) / 60
+    return when {
+        days > 0 -> "${days}d ${hours}h"
+        hours > 0 -> "${hours}h ${mins}m"
+        else -> "${mins}m"
+    }
+}

--- a/HomelabAndroid/app/src/main/java/com/homelab/app/ui/pterodactyl/PterodactylViewModel.kt
+++ b/HomelabAndroid/app/src/main/java/com/homelab/app/ui/pterodactyl/PterodactylViewModel.kt
@@ -1,0 +1,140 @@
+package com.homelab.app.ui.pterodactyl
+
+import android.content.Context
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.homelab.app.data.remote.dto.pterodactyl.PterodactylResources
+import com.homelab.app.data.remote.dto.pterodactyl.PterodactylServer
+import com.homelab.app.data.repository.PterodactylDashboardData
+import com.homelab.app.data.repository.PterodactylRepository
+import com.homelab.app.data.repository.ServicesRepository
+import com.homelab.app.domain.model.ServiceInstance
+import com.homelab.app.util.ErrorHandler
+import com.homelab.app.util.ServiceType
+import com.homelab.app.util.UiState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+data class PterodactylServerWithResources(
+    val server: PterodactylServer,
+    val resources: PterodactylResources?
+)
+
+@HiltViewModel
+class PterodactylViewModel @Inject constructor(
+    private val repository: PterodactylRepository,
+    private val servicesRepository: ServicesRepository,
+    savedStateHandle: SavedStateHandle,
+    @param:ApplicationContext private val context: Context
+) : ViewModel() {
+
+    val instanceId: String = checkNotNull(savedStateHandle["instanceId"])
+
+    private val _uiState = MutableStateFlow<UiState<List<PterodactylServerWithResources>>>(UiState.Loading)
+    val uiState: StateFlow<UiState<List<PterodactylServerWithResources>>> = _uiState.asStateFlow()
+
+    private val _isRefreshing = MutableStateFlow(false)
+    val isRefreshing: StateFlow<Boolean> = _isRefreshing.asStateFlow()
+
+    private val _actionServerId = MutableStateFlow<String?>(null)
+    val actionServerId: StateFlow<String?> = _actionServerId.asStateFlow()
+
+    private val _messages = MutableSharedFlow<String>()
+    val messages: SharedFlow<String> = _messages.asSharedFlow()
+
+    private var refreshJob: Job? = null
+    private var refreshRequestId: Long = 0L
+
+    val instances: StateFlow<List<ServiceInstance>> = servicesRepository.instancesByType
+        .map { it[ServiceType.PTERODACTYL].orEmpty() }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
+    init {
+        refresh(forceLoading = true)
+    }
+
+    fun refresh(forceLoading: Boolean = false) {
+        val requestId = ++refreshRequestId
+        refreshJob?.cancel()
+        refreshJob = viewModelScope.launch {
+            if (forceLoading || _uiState.value !is UiState.Success) {
+                _uiState.value = UiState.Loading
+            }
+            _isRefreshing.value = true
+            try {
+                val servers = repository.getServers(instanceId)
+                val enriched = coroutineScope {
+                    servers.chunked(4).flatMap { chunk ->
+                        chunk.map { server ->
+                            async {
+                                val res = runCatching {
+                                    repository.getServerResources(instanceId, server.identifier)
+                                }.getOrNull()
+                                PterodactylServerWithResources(server = server, resources = res)
+                            }
+                        }.awaitAll()
+                    }
+                }
+                _uiState.value = UiState.Success(enriched)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                _uiState.value = UiState.Error(
+                    message = ErrorHandler.getMessage(context, e),
+                    retryAction = { refresh(forceLoading = true) }
+                )
+            } finally {
+                if (requestId == refreshRequestId) {
+                    _isRefreshing.value = false
+                }
+            }
+        }
+    }
+
+    fun sendPowerSignal(identifier: String, signal: String) {
+        viewModelScope.launch {
+            _actionServerId.value = identifier
+            try {
+                repository.sendPowerSignal(instanceId, identifier, signal)
+                _messages.emit(context.getString(com.homelab.app.R.string.pterodactyl_action_sent))
+                // Poll for state change
+                repeat(6) {
+                    delay(1500L)
+                    runCatching {
+                        val updated = repository.getServerResources(instanceId, identifier)
+                        val current = _uiState.value
+                        if (current is UiState.Success) {
+                            _uiState.value = UiState.Success(
+                                current.data.map { s ->
+                                    if (s.server.identifier == identifier) s.copy(resources = updated) else s
+                                }
+                            )
+                        }
+                    }
+                }
+            } catch (e: Exception) {
+                _messages.emit(ErrorHandler.getMessage(context, e))
+            } finally {
+                _actionServerId.value = null
+            }
+        }
+    }
+}

--- a/HomelabAndroid/app/src/main/java/com/homelab/app/ui/settings/ConfiguredServicesScreen.kt
+++ b/HomelabAndroid/app/src/main/java/com/homelab/app/ui/settings/ConfiguredServicesScreen.kt
@@ -423,6 +423,8 @@ internal fun serviceDisplayNameForSettings(type: ServiceType): String {
         ServiceType.FLARESOLVERR -> stringResource(R.string.service_flaresolverr)
         ServiceType.WAKAPI -> stringResource(R.string.service_wakapi)
         ServiceType.PROXMOX -> stringResource(R.string.service_proxmox)
+        ServiceType.PTERODACTYL -> stringResource(R.string.service_pterodactyl)
+        ServiceType.CALAGOPUS -> stringResource(R.string.service_calagopus)
         ServiceType.UNKNOWN -> type.displayName
     }
 }

--- a/HomelabAndroid/app/src/main/java/com/homelab/app/ui/theme/ServiceTypeExt.kt
+++ b/HomelabAndroid/app/src/main/java/com/homelab/app/ui/theme/ServiceTypeExt.kt
@@ -62,6 +62,8 @@ val ServiceType.primaryColor: Color
         ServiceType.GLUETUN -> Color(0xFF06B6D4)
         ServiceType.FLARESOLVERR -> Color(0xFFFF4500)
         ServiceType.WAKAPI -> Color(0xFF2563EB)
+        ServiceType.PTERODACTYL -> Color(0xFF5D87FF)
+        ServiceType.CALAGOPUS -> Color(0xFF16A34A)
         ServiceType.UNKNOWN -> if (isThemeDark()) Color.LightGray else Color.Gray
     }
 
@@ -99,6 +101,8 @@ val ServiceType.backgroundColor: Color
         ServiceType.GLUETUN -> Color(0xFF06B6D4).copy(alpha = 0.12f)
         ServiceType.FLARESOLVERR -> Color(0xFFFF4500).copy(alpha = 0.12f)
         ServiceType.WAKAPI -> Color(0xFF2563EB).copy(alpha = 0.12f)
+        ServiceType.PTERODACTYL -> Color(0xFF5D87FF).copy(alpha = 0.12f)
+        ServiceType.CALAGOPUS -> Color(0xFF16A34A).copy(alpha = 0.12f)
         ServiceType.UNKNOWN -> if (isThemeDark()) Color(0xFF334155) else Color(0xFFF1F5F9)
     }
 
@@ -135,6 +139,8 @@ val ServiceType.iconUrl: String
         ServiceType.GLUETUN -> "https://cdn.jsdelivr.net/gh/selfhst/icons/png/gluetun.png"
         ServiceType.FLARESOLVERR -> "https://cdn.jsdelivr.net/gh/selfhst/icons/png/flaresolverr.png"
         ServiceType.WAKAPI -> "https://cdn.jsdelivr.net/gh/selfhst/icons/png/wakapi.png"
+        ServiceType.PTERODACTYL -> "https://cdn.jsdelivr.net/gh/selfhst/icons/png/pterodactyl.png"
+        ServiceType.CALAGOPUS -> "https://cdn.jsdelivr.net/gh/selfhst/icons/png/calagopus.png"
         ServiceType.UNKNOWN -> ""
     }
 
@@ -231,5 +237,7 @@ val ServiceType.fallbackIcon: ImageVector
         ServiceType.FLARESOLVERR -> Icons.Default.LocalFireDepartment
         ServiceType.WAKAPI -> Icons.Default.CheckCircle
         ServiceType.PROXMOX -> Icons.Default.Dns
+        ServiceType.PTERODACTYL -> Icons.Default.Dns
+        ServiceType.CALAGOPUS -> Icons.Default.Dns
         ServiceType.UNKNOWN -> Icons.Default.Widgets
     }

--- a/HomelabAndroid/app/src/main/java/com/homelab/app/util/ServiceType.kt
+++ b/HomelabAndroid/app/src/main/java/com/homelab/app/util/ServiceType.kt
@@ -37,6 +37,8 @@ enum class ServiceType(val displayName: String) {
     FLARESOLVERR("FlareSolverr"),
     WAKAPI("Wakapi"),
     PROXMOX("Proxmox VE"),
+    PTERODACTYL("Pterodactyl"),
+    CALAGOPUS("Calagopus"),
     UNKNOWN("Unknown");
 
     companion object {
@@ -76,6 +78,8 @@ enum class ServiceType(val displayName: String) {
                 "UNIFI_NETWORK" -> UNIFI_NETWORK
                 "CRAFTY",
                 "CRAFTY_CONTROLLER" -> CRAFTY_CONTROLLER
+                "PTERODACTYL" -> PTERODACTYL
+                "CALAGOPUS" -> CALAGOPUS
                 else -> entries.firstOrNull { it.name == normalized } ?: UNKNOWN
             }
         }

--- a/HomelabAndroid/app/src/main/java/com/homelab/app/util/SseClient.kt
+++ b/HomelabAndroid/app/src/main/java/com/homelab/app/util/SseClient.kt
@@ -53,6 +53,8 @@ class SseClient @Inject constructor(
                 ServiceType.WAKAPI -> "Wakapi"
                 ServiceType.CRAFTY_CONTROLLER -> "Crafty Controller"
                 ServiceType.PROXMOX -> "Proxmox"
+                ServiceType.PTERODACTYL -> "Pterodactyl"
+                ServiceType.CALAGOPUS -> "Calagopus"
                 ServiceType.UNKNOWN -> "Unknown"
             })
             .build()

--- a/HomelabAndroid/app/src/main/res/values/strings.xml
+++ b/HomelabAndroid/app/src/main/res/values/strings.xml
@@ -1796,4 +1796,49 @@
     <string name="uptime_kuma_response_time">Response</string>
     <string name="uptime_kuma_cert_days">Cert days</string>
     <string name="uptime_kuma_no_monitors">No monitors found</string>
+
+    <!-- Pterodactyl -->
+    <string name="service_pterodactyl">Pterodactyl</string>
+    <string name="service_pterodactyl_desc">Game server management panel</string>
+    <string name="login_hint_pterodactyl">Use a Pterodactyl Client API key. Generate one from your account page under API Credentials.</string>
+    <string name="pterodactyl_no_servers">No servers found for this account.</string>
+    <string name="pterodactyl_running_servers">running servers</string>
+    <string name="pterodactyl_total_servers">Total servers</string>
+    <string name="pterodactyl_cpu">CPU</string>
+    <string name="pterodactyl_ram">RAM</string>
+    <string name="pterodactyl_disk">Disk</string>
+    <string name="pterodactyl_uptime">Uptime</string>
+    <string name="pterodactyl_status_running">Running</string>
+    <string name="pterodactyl_status_stopping">Stopping</string>
+    <string name="pterodactyl_status_starting">Starting</string>
+    <string name="pterodactyl_status_offline">Offline</string>
+    <string name="pterodactyl_status_suspended">Suspended</string>
+    <string name="pterodactyl_status_installing">Installing</string>
+    <string name="pterodactyl_action_start">Start</string>
+    <string name="pterodactyl_action_stop">Stop</string>
+    <string name="pterodactyl_action_restart">Restart</string>
+    <string name="pterodactyl_action_kill">Kill</string>
+    <string name="pterodactyl_action_sent">Action sent</string>
+
+    <!-- Calagopus -->
+    <string name="service_calagopus">Calagopus</string>
+    <string name="service_calagopus_desc">Next-generation game server management panel</string>
+    <string name="login_hint_calagopus">Use a Calagopus Client API key. Generate one from your account page under API Credentials.</string>
+    <string name="calagopus_no_servers">No servers found for this account.</string>
+    <string name="calagopus_running_servers">running servers</string>
+    <string name="calagopus_total_servers">Total servers</string>
+    <string name="calagopus_cpu">CPU</string>
+    <string name="calagopus_ram">RAM</string>
+    <string name="calagopus_disk">Disk</string>
+    <string name="calagopus_uptime">Uptime</string>
+    <string name="calagopus_status_running">Running</string>
+    <string name="calagopus_status_stopping">Stopping</string>
+    <string name="calagopus_status_starting">Starting</string>
+    <string name="calagopus_status_offline">Offline</string>
+    <string name="calagopus_status_suspended">Suspended</string>
+    <string name="calagopus_action_start">Start</string>
+    <string name="calagopus_action_stop">Stop</string>
+    <string name="calagopus_action_restart">Restart</string>
+    <string name="calagopus_action_kill">Kill</string>
+    <string name="calagopus_action_sent">Action sent</string>
 </resources>

--- a/HomelabSwift/Homelab.xcodeproj/project.pbxproj
+++ b/HomelabSwift/Homelab.xcodeproj/project.pbxproj
@@ -8,17 +8,21 @@
 
 /* Begin PBXBuildFile section */
 		001FA6007779556F8CF2BDC5 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B518BC3D0A31F29612A69B75 /* Assets.xcassets */; };
+		00623F9E5FFF09815953B86C /* UniFiDashboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDFB37C2FF152CEF28395F2C /* UniFiDashboard.swift */; };
 		011C344816A77F708FD46AF1 /* PatchmonModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 853EA1B757B0BD3540F2AEED /* PatchmonModels.swift */; };
 		016D402545A7111BB261D134 /* ProxmoxHAView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2165BE8E2471EC0D1A745B5E /* ProxmoxHAView.swift */; };
+		0223089E3590C557B1077BC3 /* BookmarksStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A27E1B9D98BB24CE9CC7DD66 /* BookmarksStore.swift */; };
 		03B92E43E53FDB090D96A183 /* NpmProxyHostForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F2913EA81E6CCF74EFC883C /* NpmProxyHostForm.swift */; };
 		046CD8D1432531A4E8563885 /* ProxmoxPoolDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA26C2B4C3B48757F16F0E7B /* ProxmoxPoolDetailView.swift */; };
 		05260E0A1A5781AC8EAE7011 /* EditBookmarkView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CB770E60C2FE5FB6640BE98 /* EditBookmarkView.swift */; };
+		0608E2F28F00EDAF641EE43E /* UptimeKumaModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91BC9E73D378366DA8D3C99E /* UptimeKumaModels.swift */; };
 		06B033BE66307E6CC8E75459 /* JellystatDashboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C74A7F7C1CB466CC7223840 /* JellystatDashboard.swift */; };
 		0CDEC08F570D58E9AC6743B5 /* ProxmoxTaskLogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DB8B85BC0E01B15E9111C27 /* ProxmoxTaskLogView.swift */; };
 		0E5566DAE01FB0E9F10E98C8 /* StatusBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F5B6FAE42892F4BEB3097FD /* StatusBadge.swift */; };
 		0F634D9389BDB5467A64C25E /* GlassStatCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 735477DB04233B4FDA23469D /* GlassStatCard.swift */; };
 		106BBFAAA495E7AEACAEE51B /* CraftyAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = C24A96461E54B814B66B6815 /* CraftyAPIClient.swift */; };
 		10FBD548812295AB0814803D /* HealthchecksModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD139A00611FED93C43C0833 /* HealthchecksModels.swift */; };
+		1497D7B4F3F97AE5825880D0 /* KomodoDashboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9FA03523F30D410383AC54B /* KomodoDashboard.swift */; };
 		1694BCD702C988AAF0F99127 /* BeszelModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88B51084F8D0D0D7C999B8C3 /* BeszelModels.swift */; };
 		199E011A5729053006D89E55 /* BeszelContainersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64BA80A727F9A71D30277F9E /* BeszelContainersView.swift */; };
 		1BA6E685696F653F3CAD798A /* ProxmoxNodeDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A59E69E9542AF07ED998399 /* ProxmoxNodeDetailView.swift */; };
@@ -29,7 +33,6 @@
 		21BAB7FCB0AECC7133D55F6F /* ServiceConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 334BAFC4A25FD83F52E9CDD0 /* ServiceConnection.swift */; };
 		21E7233E678C07EF2FA629B5 /* EditCategoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F887B97554253C51BDFD167F /* EditCategoryView.swift */; };
 		22CA57F636BE4C6A5EE09760 /* DockmonAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7398039FD5D5E7D82AF14C76 /* DockmonAPIClient.swift */; };
-		234B9E87E9E44B7898DA5F44 /* KomodoAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 432A679C47684848A0D7647C /* KomodoAPIClient.swift */; };
 		22F17B053E47A71B687C63C5 /* GenericMediaDashboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D02DC8E1FAB21C2D68A01A6 /* GenericMediaDashboard.swift */; };
 		24AF53A5125B18B4F58D1A21 /* PatchmonAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEA7A42035DBFADEB256C578 /* PatchmonAPIClient.swift */; };
 		253B46BF21904B59477F2E8E /* GiteaDashboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3491FAD0D71DDB3C25D9D90 /* GiteaDashboard.swift */; };
@@ -52,6 +55,7 @@
 		462FAAA3890B72AC8A953A68 /* ProxmoxModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D78FC8BBE3C34A7255D0CAC /* ProxmoxModels.swift */; };
 		47484763DF3A83E432F37FC6 /* ProxmoxBackupJobsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8C246817EA53ED0E3950005 /* ProxmoxBackupJobsView.swift */; };
 		4CA71DBAD3D27E419ED0A10F /* NpmStreamForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA3C99077201F337CAC332D8 /* NpmStreamForm.swift */; };
+		4CF60BF28CB87B137D89A229 /* KomodoAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = C89DAA067B6D6A378553CB61 /* KomodoAPIClient.swift */; };
 		4E06A01BDB74CF4F678913CD /* AdGuardHomeDashboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10229F75137E8019ACE551D7 /* AdGuardHomeDashboard.swift */; };
 		5739C0189A11AB2E9F581D4C /* AdGuardHomeBlockedServicesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B6C9B54D25DB2230917C8F8 /* AdGuardHomeBlockedServicesView.swift */; };
 		5A1A77E754C5CDAB7A67D713 /* Translations+French.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC6C069732CC13919CD60F36 /* Translations+French.swift */; };
@@ -70,6 +74,7 @@
 		6E756D41A4E6231DF6AD016E /* LidarrModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38A351665E7EFAF8D4A3A05A /* LidarrModels.swift */; };
 		6F0B15FC2525EA13C63611B5 /* PinSetupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C61051F7EA9F32A6342570D /* PinSetupView.swift */; };
 		703D6379BB37D3F83B0C21D5 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D1604CF631BC4DC369A42A5 /* HomeView.swift */; };
+		703FA1281E0D360C5B7780C0 /* PterodactylAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C497A6F9411623A39F8CA5 /* PterodactylAPIClient.swift */; };
 		7095EBE669356384B3B42911 /* PangolinDashboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4881549A11CBCDEFA7DCFB72 /* PangolinDashboard.swift */; };
 		760733612460236D15FEC7F5 /* BeszelDetailComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFCAD7944220A8EA3DDFC3A6 /* BeszelDetailComponents.swift */; };
 		7870DA23D2B10D1CCAC08453 /* BeszelDetailTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFC214C2A851C7033ABE815 /* BeszelDetailTypes.swift */; };
@@ -91,13 +96,6 @@
 		84F415AFC1217C67B1C8D080 /* ProxmoxGuestConfigEditSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = C33B224BF42CCCC8D7E73416 /* ProxmoxGuestConfigEditSheet.swift */; };
 		889C2C456E8212B86F6EB9BB /* AdGuardHomeModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1911146A0ED528B1D912614C /* AdGuardHomeModels.swift */; };
 		8A663C3AED31DE94C751E17A /* MaltrailDashboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = B08BBF2836A4CDE120732B2E /* MaltrailDashboard.swift */; };
-		E9B7C8145B2A4F5C9D1E3062 /* UptimeKumaModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9B7C8145B2A4F5C9D1E3061 /* UptimeKumaModels.swift */; };
-		E9B7C8145B2A4F5C9D1E3064 /* UptimeKumaAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9B7C8145B2A4F5C9D1E3063 /* UptimeKumaAPIClient.swift */; };
-		E9B7C8145B2A4F5C9D1E3066 /* UptimeKumaDashboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9B7C8145B2A4F5C9D1E3065 /* UptimeKumaDashboard.swift */; };
-		E9C1A0000000000000000001 /* UniFiAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9C1A0000000000000000002 /* UniFiAPIClient.swift */; };
-		E9C1A0000000000000000003 /* UniFiDashboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9C1A0000000000000000004 /* UniFiDashboard.swift */; };
-		E9C2A0000000000000000002 /* UniFiDevicesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9C2A0000000000000000001 /* UniFiDevicesView.swift */; };
-		E9C2A0000000000000000004 /* UniFiClientsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9C2A0000000000000000003 /* UniFiClientsView.swift */; };
 		8BE00328A6AC68DF3E40F05B /* Translations+Italian.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64D8F0162AE327AA60600505 /* Translations+Italian.swift */; };
 		8DD71C55FFF77D4A370735D1 /* PlexAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF3DE80965FEEDE327E3AE34 /* PlexAPIClient.swift */; };
 		8EADC34444DEB43F553D0513 /* SkeletonLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CC9947203975F8072646659 /* SkeletonLoader.swift */; };
@@ -116,9 +114,11 @@
 		97C25FD08421A32F71C2B3BD /* NginxProxyManagerAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = D740E72A36FA4EDBFEE8A195 /* NginxProxyManagerAPIClient.swift */; };
 		9A986ED771EA2DC52308E756 /* NpmAccessListCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34DDAD2C4F4522B5980306ED /* NpmAccessListCard.swift */; };
 		9F77F33FFB5F27A3D1A8109E /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE0A64E52150CEEA94E249D7 /* ContentView.swift */; };
+		9FA99E8B665B09708A7F9D21 /* UniFiDevicesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1957898E1B523CF832C1EC7A /* UniFiDevicesView.swift */; };
 		9FAF7E857BCB519244B79DD0 /* TechnitiumDashboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DB97C476609F59700173858 /* TechnitiumDashboard.swift */; };
 		9FEE4CC03CF99116B5067700 /* SonarrModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = B971576BDCC06D4D0F3D9160 /* SonarrModels.swift */; };
 		A08D2B6FBC3D9252E47321FF /* AdGuardHomeUserRulesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44370CC6FB6ADE55FA632A02 /* AdGuardHomeUserRulesView.swift */; };
+		A15E4596A2950B61F233E229 /* UptimeKumaDashboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C16B119CB2EDEE60B4784D /* UptimeKumaDashboard.swift */; };
 		A1B0DB1FF6B1CB2BEB21B2CE /* KeychainServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCD7BB9B1065930082265D21 /* KeychainServiceTests.swift */; };
 		A283181CEA487B0C8346D967 /* PiHoleAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = B236EC8434642BB311F3E1A8 /* PiHoleAPIClient.swift */; };
 		A3DF6B4D547020804E10A0C0 /* HealthchecksDashboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4425B283650DDB0057DE0E75 /* HealthchecksDashboard.swift */; };
@@ -129,10 +129,13 @@
 		ABCECDC5B2772BE727043AA3 /* BeszelDetailSheets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E3E6D321C7DB682436A5607 /* BeszelDetailSheets.swift */; };
 		ACC3251242810B5ADED0CDD9 /* ProxmoxServicesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13A302C47CB672F515E196D5 /* ProxmoxServicesView.swift */; };
 		AD2F16BDA6D33B25BA1DD4B7 /* GiteaModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44F6D851F1B957C876FD6F0B /* GiteaModels.swift */; };
+		AD8DCE59A20032895B6C83B1 /* PterodactylDashboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47A340D4B34D2BEF223A1135 /* PterodactylDashboard.swift */; };
 		B224338F9637CC4E71D7C3E1 /* PlexDashboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EEC5D5B0AD40D7E707EC3A2 /* PlexDashboard.swift */; };
+		B3475959350ADC58148C2E6A /* UniFiAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AD961095B3F8B2101C8C66F /* UniFiAPIClient.swift */; };
 		B51871199ACBFB2987E2C165 /* PortainerModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24ACF7FA86699161F1FFB10E /* PortainerModels.swift */; };
 		B52CC2ACDDD34ADB9ECCF77B /* GiteaRepoDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBA3D966E73220F618CD9038 /* GiteaRepoDetail.swift */; };
 		B590B4E15C93B800F3AAAE3A /* ProxmoxGuestCloneSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35B72F50D3EE38BCCC908D0C /* ProxmoxGuestCloneSheet.swift */; };
+		B5EC1AE9E8F74A570F189E3D /* CalagopusDashboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B06D4217C6B4508B5E8B865 /* CalagopusDashboard.swift */; };
 		B6F34400E4C7BC4A5F752049 /* NpmProxyHostCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8569FC25F0824870C9BFD6A2 /* NpmProxyHostCard.swift */; };
 		B75BA3C1B775D95298E0933B /* SyntaxHighlighter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AD5A40912505AFD774ED713 /* SyntaxHighlighter.swift */; };
 		B8698D0D65FAC913F0591434 /* MediaDashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 310DA843851C4CF654FD3807 /* MediaDashboardView.swift */; };
@@ -144,10 +147,11 @@
 		C1CA20CED17D39FE4A99DADB /* ProxmoxGuestMigrateSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF17CF3A84B88F80A38C82BE /* ProxmoxGuestMigrateSheet.swift */; };
 		C462B63CC5FE35CD624ADFCD /* NpmStreamCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8904009FE0CC197DE3B1492A /* NpmStreamCard.swift */; };
 		C6542378592F0A5E5B44BFB7 /* DockmonDashboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB334FC7E3B327B41891F806 /* DockmonDashboard.swift */; };
-		C9A29D2FF9EA4DD69503D4E7 /* KomodoDashboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = E77A81341F3543189E51454F /* KomodoDashboard.swift */; };
 		C86FF5E6A543278A18B16E9B /* APIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB95F4E19C7D3082B4D6484C /* APIError.swift */; };
+		C97E7FCF77033F146747AF2E /* UniFiClientsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADE20E665B54E273AB66E450 /* UniFiClientsView.swift */; };
 		CC23054F0C872CC583502288 /* MaltrailModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE4821BAECE125BF5D455F /* MaltrailModels.swift */; };
 		CC2C094024169C94BD06958F /* LinuxUpdateAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC7D0097236C2F692BCAB383 /* LinuxUpdateAPIClient.swift */; };
+		CC8DE4D3D830FF7F610EDF1B /* CalagopusAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6159D00710B8E9BA71CAFDC0 /* CalagopusAPIClient.swift */; };
 		CD29007C4FB0AD271F85673C /* JellystatAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0D364FA7AED9BAC9B522C01 /* JellystatAPIClient.swift */; };
 		CE78DBCA639D954A7CCB26D3 /* ServiceErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBB688D017EE8175FB27EC7D /* ServiceErrorView.swift */; };
 		CF0124025064FF55FAD14233 /* BeszelDashboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 408F0E514FDE46F6A78D0A58 /* BeszelDashboard.swift */; };
@@ -164,7 +168,6 @@
 		D99466C32D977BCE5D9A029E /* GiteaAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15D7F6591D7ABB7E8CB96944 /* GiteaAPIClient.swift */; };
 		DDA0B198DFA935B2BF9FCE94 /* BackupModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39AD858A4CEA15DE099AC986 /* BackupModels.swift */; };
 		DE0AF6EEB06542387F08BA08 /* DockmonModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A9F6388FB1B6AA57648FF16 /* DockmonModels.swift */; };
-		D657364AD74B46C996908E54 /* KomodoModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE21903024124F58A20874D5 /* KomodoModels.swift */; };
 		DF86CB1FB4E3E32A79142588 /* BookmarksView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BCDF60E05C067D5675AB59F /* BookmarksView.swift */; };
 		E41A618C772AD13F86272FB8 /* BackupCrypto.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF7BDBCDBE58A73C0B9AF6CC /* BackupCrypto.swift */; };
 		E41C86CEB570A40EFB82ED17 /* WakapiDashboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4742ECB110ED743BABA54DEE /* WakapiDashboard.swift */; };
@@ -179,8 +182,10 @@
 		EC9F7C6B42D988E3D6D1E8BB /* PiHoleModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30BCF4718684D1491D028063 /* PiHoleModels.swift */; };
 		EDFF65DD1D2A1F388BF64B2F /* NginxProxyManagerModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = A69EDC601F02DCA97FEBAC18 /* NginxProxyManagerModels.swift */; };
 		F08A9289C496B8D4A6810332 /* Bookmark.swift in Sources */ = {isa = PBXBuildFile; fileRef = 773865BCB947A8885DA8DF37 /* Bookmark.swift */; };
+		F4B00EE3F52A758D705D681D /* UptimeKumaAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D9280578F663114BB8569D5 /* UptimeKumaAPIClient.swift */; };
 		F5EF663AA6770602771BD2F2 /* PortainerAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A576049FF063B4EC98E28D9 /* PortainerAPIClient.swift */; };
 		FA05008C0CDD05AB6854DE13 /* ProxmoxDashboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26225B537AD932B159EB30CB /* ProxmoxDashboard.swift */; };
+		FA7A4B88DACB08CBE39AAF48 /* KomodoModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF8FC831B3CEAF0F068CA2BD /* KomodoModels.swift */; };
 		FAF059D26F6524AD3CCFDA3E /* ProxmoxNetworkView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A7D5276460CD3D1AEFCC1C /* ProxmoxNetworkView.swift */; };
 		FCBBD24B21419227C44FCC60 /* LockScreenView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31E3BE5DA5D18FB8959F7C8C /* LockScreenView.swift */; };
 		FCD41D6BE7DB010018902C63 /* PinEntryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 465DB3CC355F5F7FDDF6DE00 /* PinEntryView.swift */; };
@@ -212,7 +217,9 @@
 		1474391595DB64C568F77CE2 /* ProxmoxAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProxmoxAPIClient.swift; sourceTree = "<group>"; };
 		151F3E3C716170F5B65A688F /* SettingsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsStore.swift; sourceTree = "<group>"; };
 		15D7F6591D7ABB7E8CB96944 /* GiteaAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiteaAPIClient.swift; sourceTree = "<group>"; };
+		18C16B119CB2EDEE60B4784D /* UptimeKumaDashboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UptimeKumaDashboard.swift; sourceTree = "<group>"; };
 		1911146A0ED528B1D912614C /* AdGuardHomeModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdGuardHomeModels.swift; sourceTree = "<group>"; };
+		1957898E1B523CF832C1EC7A /* UniFiDevicesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UniFiDevicesView.swift; sourceTree = "<group>"; };
 		19F58DFAF2218D934F936D17 /* HomelabApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomelabApp.swift; sourceTree = "<group>"; };
 		1B6C9B54D25DB2230917C8F8 /* AdGuardHomeBlockedServicesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdGuardHomeBlockedServicesView.swift; sourceTree = "<group>"; };
 		1D7E07D5410F384A295BD284 /* Translations+Spanish.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Translations+Spanish.swift"; sourceTree = "<group>"; };
@@ -248,14 +255,15 @@
 		3CFE5B253C47730D40039273 /* HealthchecksComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthchecksComponents.swift; sourceTree = "<group>"; };
 		3F5B6FAE42892F4BEB3097FD /* StatusBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusBadge.swift; sourceTree = "<group>"; };
 		408F0E514FDE46F6A78D0A58 /* BeszelDashboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BeszelDashboard.swift; sourceTree = "<group>"; };
-		432A679C47684848A0D7647C /* KomodoAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KomodoAPIClient.swift; sourceTree = "<group>"; };
 		4425B283650DDB0057DE0E75 /* HealthchecksDashboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthchecksDashboard.swift; sourceTree = "<group>"; };
 		44370CC6FB6ADE55FA632A02 /* AdGuardHomeUserRulesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdGuardHomeUserRulesView.swift; sourceTree = "<group>"; };
 		44F6D851F1B957C876FD6F0B /* GiteaModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiteaModels.swift; sourceTree = "<group>"; };
 		465DB3CC355F5F7FDDF6DE00 /* PinEntryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinEntryView.swift; sourceTree = "<group>"; };
 		4742ECB110ED743BABA54DEE /* WakapiDashboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WakapiDashboard.swift; sourceTree = "<group>"; };
+		47A340D4B34D2BEF223A1135 /* PterodactylDashboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PterodactylDashboard.swift; sourceTree = "<group>"; };
 		486E817863BA2B5DA5318488 /* GlassCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlassCard.swift; sourceTree = "<group>"; };
 		4881549A11CBCDEFA7DCFB72 /* PangolinDashboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PangolinDashboard.swift; sourceTree = "<group>"; };
+		49C497A6F9411623A39F8CA5 /* PterodactylAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PterodactylAPIClient.swift; sourceTree = "<group>"; };
 		4C74A7F7C1CB466CC7223840 /* JellystatDashboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JellystatDashboard.swift; sourceTree = "<group>"; };
 		4E1A77FA193DE78992A80B91 /* HomelabTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = HomelabTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		4E1E8A717351D5E42B2696F1 /* BeszelAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BeszelAPIClient.swift; sourceTree = "<group>"; };
@@ -270,12 +278,14 @@
 		5EF76E1EC7E853732127B6AA /* ProxmoxGuestDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProxmoxGuestDetailView.swift; sourceTree = "<group>"; };
 		5F1F09E5D4D69F8311840E4F /* ServiceLoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceLoginView.swift; sourceTree = "<group>"; };
 		5F7EDC22BCE4C069B41BA65C /* RadarrModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarrModels.swift; sourceTree = "<group>"; };
+		6159D00710B8E9BA71CAFDC0 /* CalagopusAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalagopusAPIClient.swift; sourceTree = "<group>"; };
 		61FF27D860A84E8974681CFE /* QbittorrentModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QbittorrentModels.swift; sourceTree = "<group>"; };
 		64BA80A727F9A71D30277F9E /* BeszelContainersView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BeszelContainersView.swift; sourceTree = "<group>"; };
 		64D8F0162AE327AA60600505 /* Translations+Italian.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Translations+Italian.swift"; sourceTree = "<group>"; };
 		69F4F3A42D23E0520D3EE3D4 /* RadarrAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadarrAPIClient.swift; sourceTree = "<group>"; };
 		6A576049FF063B4EC98E28D9 /* PortainerAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortainerAPIClient.swift; sourceTree = "<group>"; };
 		6AD5A40912505AFD774ED713 /* SyntaxHighlighter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyntaxHighlighter.swift; sourceTree = "<group>"; };
+		6AD961095B3F8B2101C8C66F /* UniFiAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UniFiAPIClient.swift; sourceTree = "<group>"; };
 		6C61051F7EA9F32A6342570D /* PinSetupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinSetupView.swift; sourceTree = "<group>"; };
 		6EF6E7AF1CDC6676B7421A7B /* HapticManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HapticManager.swift; sourceTree = "<group>"; };
 		720C06DC422C83CEF5E542D0 /* LidarrAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LidarrAPIClient.swift; sourceTree = "<group>"; };
@@ -285,6 +295,7 @@
 		7692F78990DA606D426BA429 /* Translations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Translations.swift; sourceTree = "<group>"; };
 		773865BCB947A8885DA8DF37 /* Bookmark.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bookmark.swift; sourceTree = "<group>"; };
 		794B793766A1B499D331C639 /* LidarrDashboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LidarrDashboard.swift; sourceTree = "<group>"; };
+		7B06D4217C6B4508B5E8B865 /* CalagopusDashboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalagopusDashboard.swift; sourceTree = "<group>"; };
 		7BCDF60E05C067D5675AB59F /* BookmarksView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksView.swift; sourceTree = "<group>"; };
 		7D78FC8BBE3C34A7255D0CAC /* ProxmoxModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProxmoxModels.swift; sourceTree = "<group>"; };
 		7E6FEE939313E58D34CE4BDB /* ServiceType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceType.swift; sourceTree = "<group>"; };
@@ -296,7 +307,9 @@
 		8904009FE0CC197DE3B1492A /* NpmStreamCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NpmStreamCard.swift; sourceTree = "<group>"; };
 		8D02DC8E1FAB21C2D68A01A6 /* GenericMediaDashboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericMediaDashboard.swift; sourceTree = "<group>"; };
 		8D1604CF631BC4DC369A42A5 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
+		8D9280578F663114BB8569D5 /* UptimeKumaAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UptimeKumaAPIClient.swift; sourceTree = "<group>"; };
 		915D9BA2E760A11C22688E74 /* ProxmoxConsoleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProxmoxConsoleView.swift; sourceTree = "<group>"; };
+		91BC9E73D378366DA8D3C99E /* UptimeKumaModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UptimeKumaModels.swift; sourceTree = "<group>"; };
 		944D35E4ACAB84F64B2DD3B4 /* ProxmoxCephView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProxmoxCephView.swift; sourceTree = "<group>"; };
 		94D7A0C04FD3A10D46F836A9 /* ModelDecodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelDecodingTests.swift; sourceTree = "<group>"; };
 		9578616120B5FC6C6CBC942C /* SonarrAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SonarrAPIClient.swift; sourceTree = "<group>"; };
@@ -314,6 +327,7 @@
 		9F233D9CF75937405674EEE4 /* NpmRedirectionHostCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NpmRedirectionHostCard.swift; sourceTree = "<group>"; };
 		A1BF1197F8BB03BE213E2995 /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
 		A1C0C96DF48BA12ABCC04C11 /* BackupModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupModelsTests.swift; sourceTree = "<group>"; };
+		A27E1B9D98BB24CE9CC7DD66 /* BookmarksStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksStore.swift; sourceTree = "<group>"; };
 		A3491FAD0D71DDB3C25D9D90 /* GiteaDashboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiteaDashboard.swift; sourceTree = "<group>"; };
 		A4589116BA4857CFFC0687E1 /* NpmCertificateCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NpmCertificateCard.swift; sourceTree = "<group>"; };
 		A69EDC601F02DCA97FEBAC18 /* NginxProxyManagerModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NginxProxyManagerModels.swift; sourceTree = "<group>"; };
@@ -321,15 +335,9 @@
 		AA26C2B4C3B48757F16F0E7B /* ProxmoxPoolDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProxmoxPoolDetailView.swift; sourceTree = "<group>"; };
 		AB95F4E19C7D3082B4D6484C /* APIError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIError.swift; sourceTree = "<group>"; };
 		AD139A00611FED93C43C0833 /* HealthchecksModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthchecksModels.swift; sourceTree = "<group>"; };
+		ADE20E665B54E273AB66E450 /* UniFiClientsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UniFiClientsView.swift; sourceTree = "<group>"; };
 		AE1461ABFFED5C380B73195B /* AdGuardHomeFiltersView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdGuardHomeFiltersView.swift; sourceTree = "<group>"; };
 		B08BBF2836A4CDE120732B2E /* MaltrailDashboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaltrailDashboard.swift; sourceTree = "<group>"; };
-		E9B7C8145B2A4F5C9D1E3061 /* UptimeKumaModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UptimeKumaModels.swift; sourceTree = "<group>"; };
-		E9B7C8145B2A4F5C9D1E3063 /* UptimeKumaAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UptimeKumaAPIClient.swift; sourceTree = "<group>"; };
-		E9B7C8145B2A4F5C9D1E3065 /* UptimeKumaDashboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UptimeKumaDashboard.swift; sourceTree = "<group>"; };
-		E9C1A0000000000000000002 /* UniFiAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UniFiAPIClient.swift; sourceTree = "<group>"; };
-		E9C1A0000000000000000004 /* UniFiDashboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UniFiDashboard.swift; sourceTree = "<group>"; };
-		E9C2A0000000000000000001 /* UniFiDevicesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UniFiDevicesView.swift; sourceTree = "<group>"; };
-		E9C2A0000000000000000003 /* UniFiClientsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UniFiClientsView.swift; sourceTree = "<group>"; };
 		B0D364FA7AED9BAC9B522C01 /* JellystatAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JellystatAPIClient.swift; sourceTree = "<group>"; };
 		B0F5CFB96CB606EB9EC34EBB /* AdGuardHomeAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdGuardHomeAPIClient.swift; sourceTree = "<group>"; };
 		B1EBFFF57A15B47F78E81D04 /* Formatters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Formatters.swift; sourceTree = "<group>"; };
@@ -340,7 +348,6 @@
 		B971576BDCC06D4D0F3D9160 /* SonarrModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SonarrModels.swift; sourceTree = "<group>"; };
 		BA8931C718CFC9019DCFF462 /* BookmarkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkManager.swift; sourceTree = "<group>"; };
 		BB334FC7E3B327B41891F806 /* DockmonDashboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockmonDashboard.swift; sourceTree = "<group>"; };
-		E77A81341F3543189E51454F /* KomodoDashboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KomodoDashboard.swift; sourceTree = "<group>"; };
 		BB3E11D0571609D7927FCD5A /* AdGuardHomeQueryLogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdGuardHomeQueryLogView.swift; sourceTree = "<group>"; };
 		BB7A6237B741BF62F16D9F8B /* OfflineBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineBanner.swift; sourceTree = "<group>"; };
 		BE0A64E52150CEEA94E249D7 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -348,14 +355,16 @@
 		BF17CF3A84B88F80A38C82BE /* ProxmoxGuestMigrateSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProxmoxGuestMigrateSheet.swift; sourceTree = "<group>"; };
 		BF7BDBCDBE58A73C0B9AF6CC /* BackupCrypto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupCrypto.swift; sourceTree = "<group>"; };
 		C0DE4821BAECE125BF5D455F /* MaltrailModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaltrailModels.swift; sourceTree = "<group>"; };
-		EE21903024124F58A20874D5 /* KomodoModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KomodoModels.swift; sourceTree = "<group>"; };
 		C226A2E333FD0452D26FF967 /* PiholeDomain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PiholeDomain.swift; sourceTree = "<group>"; };
 		C24A96461E54B814B66B6815 /* CraftyAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CraftyAPIClient.swift; sourceTree = "<group>"; };
 		C33B224BF42CCCC8D7E73416 /* ProxmoxGuestConfigEditSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProxmoxGuestConfigEditSheet.swift; sourceTree = "<group>"; };
 		C444B827E878BDFFC5BA3C7C /* WakapiAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WakapiAPIClient.swift; sourceTree = "<group>"; };
 		C4834BF58C4F9B1399553F78 /* CategoryFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryFormView.swift; sourceTree = "<group>"; };
 		C7F560D9B1083811461B4B44 /* Signing.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Signing.xcconfig; sourceTree = "<group>"; };
+		C89DAA067B6D6A378553CB61 /* KomodoAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KomodoAPIClient.swift; sourceTree = "<group>"; };
+		C9FA03523F30D410383AC54B /* KomodoDashboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KomodoDashboard.swift; sourceTree = "<group>"; };
 		CBA3D966E73220F618CD9038 /* GiteaRepoDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiteaRepoDetail.swift; sourceTree = "<group>"; };
+		CF8FC831B3CEAF0F068CA2BD /* KomodoModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KomodoModels.swift; sourceTree = "<group>"; };
 		D24CCA4D77154824B51544FF /* ProxmoxStorageContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProxmoxStorageContentView.swift; sourceTree = "<group>"; };
 		D740E72A36FA4EDBFEE8A195 /* NginxProxyManagerAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NginxProxyManagerAPIClient.swift; sourceTree = "<group>"; };
 		D7A7931FCA8BA5A9AA1BD3E6 /* Homelab.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Homelab.entitlements; sourceTree = "<group>"; };
@@ -380,6 +389,7 @@
 		FC6C069732CC13919CD60F36 /* Translations+French.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Translations+French.swift"; sourceTree = "<group>"; };
 		FC89D463559422B61BC300AF /* ContainerDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainerDetailView.swift; sourceTree = "<group>"; };
 		FCD7BB9B1065930082265D21 /* KeychainServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainServiceTests.swift; sourceTree = "<group>"; };
+		FDFB37C2FF152CEF28395F2C /* UniFiDashboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UniFiDashboard.swift; sourceTree = "<group>"; };
 		FE7A7BFF374B6DE9CE7384EE /* PiHoleDashboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PiHoleDashboard.swift; sourceTree = "<group>"; };
 		FEF0A029C7F3CF79994A268B /* NpmRedirectionHostForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NpmRedirectionHostForm.swift; sourceTree = "<group>"; };
 		FEF389260911EADF7079A97B /* APIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClient.swift; sourceTree = "<group>"; };
@@ -444,6 +454,22 @@
 			path = AdGuardHome;
 			sourceTree = "<group>";
 		};
+		0CDA3454933CE4C859BCE287 /* Calagopus */ = {
+			isa = PBXGroup;
+			children = (
+				6159D00710B8E9BA71CAFDC0 /* CalagopusAPIClient.swift */,
+			);
+			path = Calagopus;
+			sourceTree = "<group>";
+		};
+		0D47235EA9B3E7ABB54D915C /* Komodo */ = {
+			isa = PBXGroup;
+			children = (
+				C89DAA067B6D6A378553CB61 /* KomodoAPIClient.swift */,
+			);
+			path = Komodo;
+			sourceTree = "<group>";
+		};
 		0DCA760FCED4DB1FA63644CB /* Qbittorrent */ = {
 			isa = PBXGroup;
 			children = (
@@ -480,6 +506,14 @@
 				B95B7C501526C761049BD34F /* Views */,
 			);
 			path = Homelab;
+			sourceTree = "<group>";
+		};
+		12DB927C145E608B87596524 /* UptimeKuma */ = {
+			isa = PBXGroup;
+			children = (
+				8D9280578F663114BB8569D5 /* UptimeKumaAPIClient.swift */,
+			);
+			path = UptimeKuma;
 			sourceTree = "<group>";
 		};
 		14E1ED932033D48687A9AEFA /* LinuxUpdate */ = {
@@ -530,12 +564,36 @@
 			path = Gitea;
 			sourceTree = "<group>";
 		};
+		2A11C19BD60250B7E009AD55 /* Calagopus */ = {
+			isa = PBXGroup;
+			children = (
+				7B06D4217C6B4508B5E8B865 /* CalagopusDashboard.swift */,
+			);
+			path = Calagopus;
+			sourceTree = "<group>";
+		};
+		315D15A9A015777069607D57 /* Komodo */ = {
+			isa = PBXGroup;
+			children = (
+				C9FA03523F30D410383AC54B /* KomodoDashboard.swift */,
+			);
+			path = Komodo;
+			sourceTree = "<group>";
+		};
 		34CF45919C322CA4B3EF1E3B /* Store */ = {
 			isa = PBXGroup;
 			children = (
 				BA8931C718CFC9019DCFF462 /* BookmarkManager.swift */,
 			);
 			path = Store;
+			sourceTree = "<group>";
+		};
+		37812033DFDA5B72BB1A466F /* UniFi */ = {
+			isa = PBXGroup;
+			children = (
+				6AD961095B3F8B2101C8C66F /* UniFiAPIClient.swift */,
+			);
+			path = UniFi;
 			sourceTree = "<group>";
 		};
 		3A1C2051810E696AD09E6C3B /* AdGuardHome */ = {
@@ -591,17 +649,17 @@
 				3A1C2051810E696AD09E6C3B /* AdGuardHome */,
 				9C3998846D55F959084051D2 /* Beszel */,
 				A68D8B4B5D526100A0F56D85 /* Dockmon */,
-				A51C3C6205A14998A35D3DBF /* Komodo */,
 				981FC3E8A73DC27EF4792684 /* Gitea */,
 				69A014381BA51401C9862848 /* Healthchecks */,
+				66B23206214A52D44AB0F489 /* Komodo */,
 				14E1ED932033D48687A9AEFA /* LinuxUpdate */,
 				9296229844E2867993B7CDC5 /* Maltrail */,
-				E9B7C8145B2A4F5C9D1E3067 /* UptimeKuma */,
 				F3AB0740CCD7B809F06B451A /* NginxProxyManager */,
 				FBC83234CE88E51531A08129 /* Patchmon */,
 				F2BD8B68C5C78ECC6C3C024A /* PiHole */,
 				1E866E8511A219B4C76B9235 /* Portainer */,
 				95BCC083816D8AA934FDC8F5 /* Proxmox */,
+				E4365D1267750E9B89EF936F /* UptimeKuma */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -612,6 +670,14 @@
 				B0D364FA7AED9BAC9B522C01 /* JellystatAPIClient.swift */,
 			);
 			path = Jellystat;
+			sourceTree = "<group>";
+		};
+		57FF521E60BE1C1521AB5193 /* Pterodactyl */ = {
+			isa = PBXGroup;
+			children = (
+				49C497A6F9411623A39F8CA5 /* PterodactylAPIClient.swift */,
+			);
+			path = Pterodactyl;
 			sourceTree = "<group>";
 		};
 		58F8A8040064B68291A0616F /* ServiceLogin */ = {
@@ -655,6 +721,14 @@
 				4C74A7F7C1CB466CC7223840 /* JellystatDashboard.swift */,
 			);
 			path = Jellystat;
+			sourceTree = "<group>";
+		};
+		66B23206214A52D44AB0F489 /* Komodo */ = {
+			isa = PBXGroup;
+			children = (
+				CF8FC831B3CEAF0F068CA2BD /* KomodoModels.swift */,
+			);
+			path = Komodo;
 			sourceTree = "<group>";
 		};
 		69A014381BA51401C9862848 /* Healthchecks */ = {
@@ -733,6 +807,7 @@
 		7DAFCB2BF30198F989D7E950 /* Stores */ = {
 			isa = PBXGroup;
 			children = (
+				A27E1B9D98BB24CE9CC7DD66 /* BookmarksStore.swift */,
 				258507E3A00D686FDEF7E9CE /* ServicesStore.swift */,
 				151F3E3C716170F5B65A688F /* SettingsStore.swift */,
 			);
@@ -745,6 +820,14 @@
 				0726BE937688EDCEF843DA4A /* MaltrailAPIClient.swift */,
 			);
 			path = Maltrail;
+			sourceTree = "<group>";
+		};
+		83DA3DAE15FBB9494FDF9EAD /* UptimeKuma */ = {
+			isa = PBXGroup;
+			children = (
+				18C16B119CB2EDEE60B4784D /* UptimeKumaDashboard.swift */,
+			);
+			path = UptimeKuma;
 			sourceTree = "<group>";
 		};
 		845E4EB9D4DE085F19044DDD /* Plex */ = {
@@ -786,24 +869,6 @@
 				B08BBF2836A4CDE120732B2E /* MaltrailDashboard.swift */,
 			);
 			path = Maltrail;
-			sourceTree = "<group>";
-		};
-		E9B7C8145B2A4F5C9D1E3069 /* UptimeKuma */ = {
-			isa = PBXGroup;
-			children = (
-				E9B7C8145B2A4F5C9D1E3065 /* UptimeKumaDashboard.swift */,
-			);
-			path = UptimeKuma;
-			sourceTree = "<group>";
-		};
-		E9C1A0000000000000000005 /* UniFi */ = {
-			isa = PBXGroup;
-			children = (
-				E9C1A0000000000000000004 /* UniFiDashboard.swift */,
-				E9C2A0000000000000000001 /* UniFiDevicesView.swift */,
-				E9C2A0000000000000000003 /* UniFiClientsView.swift */,
-			);
-			path = UniFi;
 			sourceTree = "<group>";
 		};
 		8A7222B61ABE4DC99B26EDA7 /* Crafty */ = {
@@ -850,22 +915,6 @@
 				C0DE4821BAECE125BF5D455F /* MaltrailModels.swift */,
 			);
 			path = Maltrail;
-			sourceTree = "<group>";
-		};
-		E9B7C8145B2A4F5C9D1E3067 /* UptimeKuma */ = {
-			isa = PBXGroup;
-			children = (
-				E9B7C8145B2A4F5C9D1E3061 /* UptimeKumaModels.swift */,
-			);
-			path = UptimeKuma;
-			sourceTree = "<group>";
-		};
-		E9C1A0000000000000000006 /* UniFi */ = {
-			isa = PBXGroup;
-			children = (
-				E9C1A0000000000000000002 /* UniFiAPIClient.swift */,
-			);
-			path = UniFi;
 			sourceTree = "<group>";
 		};
 		95BCC083816D8AA934FDC8F5 /* Proxmox */ = {
@@ -933,20 +982,20 @@
 			path = Services;
 			sourceTree = "<group>";
 		};
+		A1925BFC390951DBAEFCF382 /* Pterodactyl */ = {
+			isa = PBXGroup;
+			children = (
+				47A340D4B34D2BEF223A1135 /* PterodactylDashboard.swift */,
+			);
+			path = Pterodactyl;
+			sourceTree = "<group>";
+		};
 		A68D8B4B5D526100A0F56D85 /* Dockmon */ = {
 			isa = PBXGroup;
 			children = (
 				3A9F6388FB1B6AA57648FF16 /* DockmonModels.swift */,
 			);
 			path = Dockmon;
-			sourceTree = "<group>";
-		};
-		A51C3C6205A14998A35D3DBF /* Komodo */ = {
-			isa = PBXGroup;
-			children = (
-				EE21903024124F58A20874D5 /* KomodoModels.swift */,
-			);
-			path = Komodo;
 			sourceTree = "<group>";
 		};
 		ABC55F19459A78E216C60C0A /* Wakapi */ = {
@@ -981,20 +1030,19 @@
 				09F190CFB0DE143E71104529 /* AdGuardHome */,
 				F1265188363BF5B5C00056A5 /* Beszel */,
 				ECAF9E33BDB4EE0FFFF630D0 /* Bookmarks */,
+				2A11C19BD60250B7E009AD55 /* Calagopus */,
 				5A93214C3BDCB9BEC5FCCD73 /* Components */,
 				766B8D5D15CBF16824D30AD0 /* Crafty */,
 				D544ABDB8DF1FE38D7862D8B /* Dockhand */,
 				F2881EEEFF55D4BF25DA6F20 /* Dockmon */,
-				A52C3C6205A14998A35D3DBF /* Komodo */,
 				48AAFFAA1096205CCB4685B8 /* Gitea */,
 				73413D1CE20FEEB055D5D6DD /* Healthchecks */,
 				873F7F23714AC880CCFDA5BF /* Home */,
 				5C653FDCC31984516D486E0F /* Jellystat */,
+				315D15A9A015777069607D57 /* Komodo */,
 				59689F328ECB35DE4A5FD7C4 /* Lidarr */,
 				922AD3CD77717AA4927E1C6F /* LinuxUpdate */,
 				8A6AA03DA4BF8904504DBDA8 /* Maltrail */,
-				E9B7C8145B2A4F5C9D1E3069 /* UptimeKuma */,
-				E9C1A0000000000000000005 /* UniFi */,
 				B5B73DED8852F94FA4F1DB7F /* Media */,
 				710B37A9B027F4C732FAA0E0 /* NginxProxyManager */,
 				4D773C488C27A57846186D6C /* Pangolin */,
@@ -1003,6 +1051,7 @@
 				C2576757631234A14F69F54D /* Plex */,
 				EB0D5A2B9725AD26C768879F /* Portainer */,
 				7A0EE3A34C2ED62339F4E9C6 /* Proxmox */,
+				A1925BFC390951DBAEFCF382 /* Pterodactyl */,
 				D77B94FB61E2B2E507356620 /* Qbittorrent */,
 				D6D52F145CED85D0B4945C73 /* Radarr */,
 				092E6DA6764D5AD6F0361A22 /* Security */,
@@ -1010,6 +1059,8 @@
 				0484D4BF357548D950ABB56C /* Settings */,
 				971DDC6643DF517A71F1E0AA /* Sonarr */,
 				1B3FF86FA121ED2FFB8BC270 /* Technitium */,
+				C7EDDE8C2FB40CF792552D6B /* UniFi */,
+				83DA3DAE15FBB9494FDF9EAD /* UptimeKuma */,
 				84FA10F3C1B14B2C55E58EE3 /* Wakapi */,
 			);
 			path = Views;
@@ -1037,6 +1088,16 @@
 				9EEC5D5B0AD40D7E707EC3A2 /* PlexDashboard.swift */,
 			);
 			path = Plex;
+			sourceTree = "<group>";
+		};
+		C7EDDE8C2FB40CF792552D6B /* UniFi */ = {
+			isa = PBXGroup;
+			children = (
+				ADE20E665B54E273AB66E450 /* UniFiClientsView.swift */,
+				FDFB37C2FF152CEF28395F2C /* UniFiDashboard.swift */,
+				1957898E1B523CF832C1EC7A /* UniFiDevicesView.swift */,
+			);
+			path = UniFi;
 			sourceTree = "<group>";
 		};
 		C9F6FE4041AA55D79004BC56 /* Config */ = {
@@ -1096,17 +1157,16 @@
 				34351F37F1A0778D6CFC90B3 /* GenericAPIClient.swift */,
 				0FF3AB848856515A57C1F122 /* AdGuardHome */,
 				D5B24EF44902FCBD35F6D145 /* Beszel */,
+				0CDA3454933CE4C859BCE287 /* Calagopus */,
 				8A7222B61ABE4DC99B26EDA7 /* Crafty */,
 				E7700DDE3FA87FCC29C7446A /* Dockmon */,
-				A53C3C6205A14998A35D3DBF /* Komodo */,
 				289C5939524BACC32CDCCF25 /* Gitea */,
 				06347246AD362987E7E3A1D3 /* Healthchecks */,
 				4DF24834910915FEAB043587 /* Jellystat */,
+				0D47235EA9B3E7ABB54D915C /* Komodo */,
 				9B045F71B3B23D93B967B53A /* Lidarr */,
 				4C90EF8FCC9EEF95D9AB014C /* LinuxUpdate */,
 				7EE465F8B66B567A6A7A2622 /* Maltrail */,
-				E9B7C8145B2A4F5C9D1E3068 /* UptimeKuma */,
-				E9C1A0000000000000000006 /* UniFi */,
 				23AB1F8E0947D3598E65C623 /* NginxProxyManager */,
 				1E129360F625134B518C39D4 /* Pangolin */,
 				AEF3A1B12CFF68006D2F06AF /* Patchmon */,
@@ -1114,10 +1174,13 @@
 				845E4EB9D4DE085F19044DDD /* Plex */,
 				3B0F0ED088E1700C927989C0 /* Portainer */,
 				C1C2A2A47873605601F77C49 /* Proxmox */,
+				57FF521E60BE1C1521AB5193 /* Pterodactyl */,
 				0DCA760FCED4DB1FA63644CB /* Qbittorrent */,
 				FCECFC579C82906D02D48580 /* Radarr */,
 				02E6C0863A40CA732CDE1B37 /* Sonarr */,
 				084D2436AFFE34C15D089A1D /* Technitium */,
+				37812033DFDA5B72BB1A466F /* UniFi */,
+				12DB927C145E608B87596524 /* UptimeKuma */,
 				ABC55F19459A78E216C60C0A /* Wakapi */,
 			);
 			path = Networking;
@@ -1144,28 +1207,20 @@
 			path = HomelabTests;
 			sourceTree = "<group>";
 		};
+		E4365D1267750E9B89EF936F /* UptimeKuma */ = {
+			isa = PBXGroup;
+			children = (
+				91BC9E73D378366DA8D3C99E /* UptimeKumaModels.swift */,
+			);
+			path = UptimeKuma;
+			sourceTree = "<group>";
+		};
 		E7700DDE3FA87FCC29C7446A /* Dockmon */ = {
 			isa = PBXGroup;
 			children = (
 				7398039FD5D5E7D82AF14C76 /* DockmonAPIClient.swift */,
 			);
 			path = Dockmon;
-			sourceTree = "<group>";
-		};
-		E9B7C8145B2A4F5C9D1E3068 /* UptimeKuma */ = {
-			isa = PBXGroup;
-			children = (
-				E9B7C8145B2A4F5C9D1E3063 /* UptimeKumaAPIClient.swift */,
-			);
-			path = UptimeKuma;
-			sourceTree = "<group>";
-		};
-		A53C3C6205A14998A35D3DBF /* Komodo */ = {
-			isa = PBXGroup;
-			children = (
-				432A679C47684848A0D7647C /* KomodoAPIClient.swift */,
-			);
-			path = Komodo;
 			sourceTree = "<group>";
 		};
 		EB0C2E8A1FE201A265D4FC4A /* Utilities */ = {
@@ -1221,14 +1276,6 @@
 				BB334FC7E3B327B41891F806 /* DockmonDashboard.swift */,
 			);
 			path = Dockmon;
-			sourceTree = "<group>";
-		};
-		A52C3C6205A14998A35D3DBF /* Komodo */ = {
-			isa = PBXGroup;
-			children = (
-				E77A81341F3543189E51454F /* KomodoDashboard.swift */,
-			);
-			path = Komodo;
 			sourceTree = "<group>";
 		};
 		F2BD8B68C5C78ECC6C3C024A /* PiHole */ = {
@@ -1313,7 +1360,7 @@
 				LastUpgradeCheck = 2600;
 				TargetAttributes = {
 					F030701E1A7DE1C00D08FE68 = {
-						DevelopmentTeam = 74584D6P85;
+						DevelopmentTeam = "";
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -1381,7 +1428,10 @@
 				F08A9289C496B8D4A6810332 /* Bookmark.swift in Sources */,
 				1FEB8EB133A5749EBE928E1C /* BookmarkFormView.swift in Sources */,
 				62EF5383568C38878FAB5623 /* BookmarkManager.swift in Sources */,
+				0223089E3590C557B1077BC3 /* BookmarksStore.swift in Sources */,
 				DF86CB1FB4E3E32A79142588 /* BookmarksView.swift in Sources */,
+				CC8DE4D3D830FF7F610EDF1B /* CalagopusAPIClient.swift in Sources */,
+				B5EC1AE9E8F74A570F189E3D /* CalagopusDashboard.swift in Sources */,
 				654B246C79458CB80AEC15D8 /* CategoryFormView.swift in Sources */,
 				91FEB90D9F7C9387B1CD8BA9 /* ConfiguredServicesView.swift in Sources */,
 				CFFCFA6F071D0F46DECAB36B /* ContainerDetailView.swift in Sources */,
@@ -1394,9 +1444,6 @@
 				22CA57F636BE4C6A5EE09760 /* DockmonAPIClient.swift in Sources */,
 				C6542378592F0A5E5B44BFB7 /* DockmonDashboard.swift in Sources */,
 				DE0AF6EEB06542387F08BA08 /* DockmonModels.swift in Sources */,
-				234B9E87E9E44B7898DA5F44 /* KomodoAPIClient.swift in Sources */,
-				C9A29D2FF9EA4DD69503D4E7 /* KomodoDashboard.swift in Sources */,
-				D657364AD74B46C996908E54 /* KomodoModels.swift in Sources */,
 				05260E0A1A5781AC8EAE7011 /* EditBookmarkView.swift in Sources */,
 				21E7233E678C07EF2FA629B5 /* EditCategoryView.swift in Sources */,
 				7E78EE55701AD004992579EF /* Formatters.swift in Sources */,
@@ -1420,6 +1467,9 @@
 				CD29007C4FB0AD271F85673C /* JellystatAPIClient.swift in Sources */,
 				06B033BE66307E6CC8E75459 /* JellystatDashboard.swift in Sources */,
 				6B883FF0F9673181B59F8C83 /* KeychainService.swift in Sources */,
+				4CF60BF28CB87B137D89A229 /* KomodoAPIClient.swift in Sources */,
+				1497D7B4F3F97AE5825880D0 /* KomodoDashboard.swift in Sources */,
+				FA7A4B88DACB08CBE39AAF48 /* KomodoModels.swift in Sources */,
 				94D317107C8A2E613083BE90 /* LidarrAPIClient.swift in Sources */,
 				E75363C9B789E7FFC1024F51 /* LidarrDashboard.swift in Sources */,
 				6E756D41A4E6231DF6AD016E /* LidarrModels.swift in Sources */,
@@ -1432,13 +1482,6 @@
 				952767CF7AF01E00666D4CF6 /* MaltrailAPIClient.swift in Sources */,
 				8A663C3AED31DE94C751E17A /* MaltrailDashboard.swift in Sources */,
 				CC23054F0C872CC583502288 /* MaltrailModels.swift in Sources */,
-				E9B7C8145B2A4F5C9D1E3064 /* UptimeKumaAPIClient.swift in Sources */,
-				E9B7C8145B2A4F5C9D1E3066 /* UptimeKumaDashboard.swift in Sources */,
-				E9B7C8145B2A4F5C9D1E3062 /* UptimeKumaModels.swift in Sources */,
-				E9C1A0000000000000000001 /* UniFiAPIClient.swift in Sources */,
-				E9C1A0000000000000000003 /* UniFiDashboard.swift in Sources */,
-				E9C2A0000000000000000002 /* UniFiDevicesView.swift in Sources */,
-				E9C2A0000000000000000004 /* UniFiClientsView.swift in Sources */,
 				B8698D0D65FAC913F0591434 /* MediaDashboardView.swift in Sources */,
 				97C25FD08421A32F71C2B3BD /* NginxProxyManagerAPIClient.swift in Sources */,
 				EDFF65DD1D2A1F388BF64B2F /* NginxProxyManagerModels.swift in Sources */,
@@ -1496,6 +1539,8 @@
 				ACC3251242810B5ADED0CDD9 /* ProxmoxServicesView.swift in Sources */,
 				2E323D5C9589F5692F02B092 /* ProxmoxStorageContentView.swift in Sources */,
 				0CDEC08F570D58E9AC6743B5 /* ProxmoxTaskLogView.swift in Sources */,
+				703FA1281E0D360C5B7780C0 /* PterodactylAPIClient.swift in Sources */,
+				AD8DCE59A20032895B6C83B1 /* PterodactylDashboard.swift in Sources */,
 				97254226660E65C1DEC0C2EE /* QbittorrentAPIClient.swift in Sources */,
 				37CBDADA59AC66BC5639663F /* QbittorrentDashboard.swift in Sources */,
 				1F2427668043AA81D0F038BE /* QbittorrentModels.swift in Sources */,
@@ -1525,6 +1570,13 @@
 				8BE00328A6AC68DF3E40F05B /* Translations+Italian.swift in Sources */,
 				3C9BDFAE94048BBD360AF601 /* Translations+Spanish.swift in Sources */,
 				AAA9BC382610A55D8E374C95 /* Translations.swift in Sources */,
+				B3475959350ADC58148C2E6A /* UniFiAPIClient.swift in Sources */,
+				C97E7FCF77033F146747AF2E /* UniFiClientsView.swift in Sources */,
+				00623F9E5FFF09815953B86C /* UniFiDashboard.swift in Sources */,
+				9FA99E8B665B09708A7F9D21 /* UniFiDevicesView.swift in Sources */,
+				F4B00EE3F52A758D705D681D /* UptimeKumaAPIClient.swift in Sources */,
+				A15E4596A2950B61F233E229 /* UptimeKumaDashboard.swift in Sources */,
+				0608E2F28F00EDAF641EE43E /* UptimeKumaModels.swift in Sources */,
 				698E6B77D281367DA484C23B /* WakapiAPIClient.swift in Sources */,
 				E41C86CEB570A40EFB82ED17 /* WakapiDashboard.swift in Sources */,
 			);

--- a/HomelabSwift/Homelab/Assets.xcassets/AppIconPreviewClearDark.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/AppIconPreviewClearDark.imageset/Contents.json
@@ -4,6 +4,14 @@
       "filename" : "icon_1024x1024.png",
       "idiom" : "universal",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {

--- a/HomelabSwift/Homelab/Assets.xcassets/AppIconPreviewClearLight.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/AppIconPreviewClearLight.imageset/Contents.json
@@ -4,6 +4,14 @@
       "filename" : "icon_1024x1024.png",
       "idiom" : "universal",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {

--- a/HomelabSwift/Homelab/Assets.xcassets/AppIconPreviewDark.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/AppIconPreviewDark.imageset/Contents.json
@@ -4,6 +4,14 @@
       "filename" : "icon_1024x1024.png",
       "idiom" : "universal",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {

--- a/HomelabSwift/Homelab/Assets.xcassets/AppIconPreviewDefault.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/AppIconPreviewDefault.imageset/Contents.json
@@ -4,6 +4,14 @@
       "filename" : "icon_1024x1024.png",
       "idiom" : "universal",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {

--- a/HomelabSwift/Homelab/Assets.xcassets/AppIconPreviewTintedDark.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/AppIconPreviewTintedDark.imageset/Contents.json
@@ -4,6 +4,14 @@
       "filename" : "icon_1024x1024.png",
       "idiom" : "universal",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {

--- a/HomelabSwift/Homelab/Assets.xcassets/AppIconPreviewTintedLight.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/AppIconPreviewTintedLight.imageset/Contents.json
@@ -4,6 +4,14 @@
       "filename" : "icon_1024x1024.png",
       "idiom" : "universal",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {

--- a/HomelabSwift/Homelab/Assets.xcassets/service-unifi.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/service-unifi.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "ubiquiti-unifi.png",
-      "scale": "1x"
+      "filename" : "ubiquiti-unifi.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-access-point-ac-mesh.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-access-point-ac-mesh.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Access Point AC Mesh.png",
-      "scale": "1x"
+      "filename" : "Access Point AC Mesh.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-access-point-ac-pro.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-access-point-ac-pro.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Access Point AC Pro.png",
-      "scale": "1x"
+      "filename" : "Access Point AC Pro.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-access-point-e7-audience.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-access-point-e7-audience.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Access Point E7 Audience.png",
-      "scale": "1x"
+      "filename" : "Access Point E7 Audience.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-access-point-e7-campus.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-access-point-e7-campus.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Access Point E7 Campus.png",
-      "scale": "1x"
+      "filename" : "Access Point E7 Campus.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-access-point-e7.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-access-point-e7.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Access Point E7.png",
-      "scale": "1x"
+      "filename" : "Access Point E7.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-access-point-u6-enterprise-in-wall.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-access-point-u6-enterprise-in-wall.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Access Point U6 Enterprise In-Wall.png",
-      "scale": "1x"
+      "filename" : "Access Point U6 Enterprise In-Wall.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-access-point-u6-enterprise.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-access-point-u6-enterprise.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Access Point U6 Enterprise.png",
-      "scale": "1x"
+      "filename" : "Access Point U6 Enterprise.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-access-point-u6-extender.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-access-point-u6-extender.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Access Point U6 Extender.png",
-      "scale": "1x"
+      "filename" : "Access Point U6 Extender.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-access-point-u6-in-wall.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-access-point-u6-in-wall.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Access Point U6 In-Wall.png",
-      "scale": "1x"
+      "filename" : "Access Point U6 In-Wall.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-access-point-u6-mesh-pro.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-access-point-u6-mesh-pro.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Access Point U6 Mesh Pro.png",
-      "scale": "1x"
+      "filename" : "Access Point U6 Mesh Pro.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-access-point-u6-mesh.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-access-point-u6-mesh.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Access Point U6 Mesh.png",
-      "scale": "1x"
+      "filename" : "Access Point U6 Mesh.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-access-point-u6-plus.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-access-point-u6-plus.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Access Point U6 Plus.png",
-      "scale": "1x"
+      "filename" : "Access Point U6 Plus.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-access-point-u6-pro.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-access-point-u6-pro.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Access Point U6 Pro.png",
-      "scale": "1x"
+      "filename" : "Access Point U6 Pro.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-access-point-u7-in-wall.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-access-point-u7-in-wall.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Access Point U7 In-Wall.png",
-      "scale": "1x"
+      "filename" : "Access Point U7 In-Wall.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-access-point-u7-lite.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-access-point-u7-lite.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Access Point U7 Lite.png",
-      "scale": "1x"
+      "filename" : "Access Point U7 Lite.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-access-point-u7-long-range.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-access-point-u7-long-range.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Access Point U7 Long-Range.png",
-      "scale": "1x"
+      "filename" : "Access Point U7 Long-Range.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-access-point-u7-mesh.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-access-point-u7-mesh.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Access Point U7 Mesh.png",
-      "scale": "1x"
+      "filename" : "Access Point U7 Mesh.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-access-point-u7-outdoor.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-access-point-u7-outdoor.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Access Point U7 Outdoor.png",
-      "scale": "1x"
+      "filename" : "Access Point U7 Outdoor.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-access-point-u7-pro-max.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-access-point-u7-pro-max.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Access Point U7 Pro Max.png",
-      "scale": "1x"
+      "filename" : "Access Point U7 Pro Max.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-access-point-u7-pro-outdoor.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-access-point-u7-pro-outdoor.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Access Point U7 Pro Outdoor.png",
-      "scale": "1x"
+      "filename" : "Access Point U7 Pro Outdoor.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-access-point-u7-pro-wall.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-access-point-u7-pro-wall.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Access Point U7 Pro Wall.png",
-      "scale": "1x"
+      "filename" : "Access Point U7 Pro Wall.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-access-point-u7-pro-xg-wall.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-access-point-u7-pro-xg-wall.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Access Point U7 Pro XG Wall.png",
-      "scale": "1x"
+      "filename" : "Access Point U7 Pro XG Wall.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-access-point-u7-pro-xg.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-access-point-u7-pro-xg.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Access Point U7 Pro XG.png",
-      "scale": "1x"
+      "filename" : "Access Point U7 Pro XG.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-access-point-u7-pro-xgs.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-access-point-u7-pro-xgs.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Access Point U7 Pro XGS.png",
-      "scale": "1x"
+      "filename" : "Access Point U7 Pro XGS.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-access-point-u7-pro.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-access-point-u7-pro.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Access Point U7 Pro.png",
-      "scale": "1x"
+      "filename" : "Access Point U7 Pro.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-airwire.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-airwire.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "AirWire.png",
-      "scale": "1x"
+      "filename" : "AirWire.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-building-to-building-bridge-xg.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-building-to-building-bridge-xg.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Building-to-Building Bridge XG.png",
-      "scale": "1x"
+      "filename" : "Building-to-Building Bridge XG.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-building-to-building-bridge.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-building-to-building-bridge.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Building-to-Building Bridge.png",
-      "scale": "1x"
+      "filename" : "Building-to-Building Bridge.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-cloud-gateway-fiber.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-cloud-gateway-fiber.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Cloud Gateway Fiber.png",
-      "scale": "1x"
+      "filename" : "Cloud Gateway Fiber.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-cloud-gateway-industrial.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-cloud-gateway-industrial.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Cloud Gateway Industrial.png",
-      "scale": "1x"
+      "filename" : "Cloud Gateway Industrial.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-cloud-gateway-max.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-cloud-gateway-max.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Cloud Gateway Max.png",
-      "scale": "1x"
+      "filename" : "Cloud Gateway Max.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-cloud-gateway-ultra.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-cloud-gateway-ultra.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Cloud Gateway Ultra.png",
-      "scale": "1x"
+      "filename" : "Cloud Gateway Ultra.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-company-2.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-company-2.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Company_2.png",
-      "scale": "1x"
+      "filename" : "Company_2.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-company-3.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-company-3.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Company_3.png",
-      "scale": "1x"
+      "filename" : "Company_3.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-company.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-company.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Company.png",
-      "scale": "1x"
+      "filename" : "Company.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-device-bridge-iot.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-device-bridge-iot.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Device Bridge IoT.png",
-      "scale": "1x"
+      "filename" : "Device Bridge IoT.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-device-bridge-pro-sector.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-device-bridge-pro-sector.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Device Bridge Pro Sector.png",
-      "scale": "1x"
+      "filename" : "Device Bridge Pro Sector.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-device-bridge-pro.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-device-bridge-pro.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Device Bridge Pro.png",
-      "scale": "1x"
+      "filename" : "Device Bridge Pro.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-device-bridge-switch.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-device-bridge-switch.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Device Bridge Switch.png",
-      "scale": "1x"
+      "filename" : "Device Bridge Switch.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-dream-machine-pro-max.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-dream-machine-pro-max.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Dream Machine Pro Max.png",
-      "scale": "1x"
+      "filename" : "Dream Machine Pro Max.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-dream-machine-pro.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-dream-machine-pro.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Dream Machine Pro.png",
-      "scale": "1x"
+      "filename" : "Dream Machine Pro.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-dream-machine-special-edition.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-dream-machine-special-edition.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Dream Machine Special Edition.png",
-      "scale": "1x"
+      "filename" : "Dream Machine Special Edition.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-dream-router-5g-max.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-dream-router-5g-max.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Dream Router 5G Max.png",
-      "scale": "1x"
+      "filename" : "Dream Router 5G Max.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-dream-router-7.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-dream-router-7.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Dream Router 7.png",
-      "scale": "1x"
+      "filename" : "Dream Router 7.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-dream-wall.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-dream-wall.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Dream Wall.png",
-      "scale": "1x"
+      "filename" : "Dream Wall.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-enterprise-fortress-gateway.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-enterprise-fortress-gateway.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Enterprise Fortress Gateway.png",
-      "scale": "1x"
+      "filename" : "Enterprise Fortress Gateway.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-flex-utility-pro.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-flex-utility-pro.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Flex Utility Pro.png",
-      "scale": "1x"
+      "filename" : "Flex Utility Pro.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-partner-program-2.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-partner-program-2.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Partner Program_2.png",
-      "scale": "1x"
+      "filename" : "Partner Program_2.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-partner-program-3.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-partner-program-3.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Partner Program_3.png",
-      "scale": "1x"
+      "filename" : "Partner Program_3.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-partner-program.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-partner-program.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Partner Program.png",
-      "scale": "1x"
+      "filename" : "Partner Program.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-swiss-army-knife.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-swiss-army-knife.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Swiss Army Knife.png",
-      "scale": "1x"
+      "filename" : "Swiss Army Knife.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-16-poe.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-16-poe.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Switch 16 PoE.png",
-      "scale": "1x"
+      "filename" : "Switch 16 PoE.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-24-poe.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-24-poe.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Switch 24 PoE.png",
-      "scale": "1x"
+      "filename" : "Switch 24 PoE.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-24.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-24.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Switch 24.png",
-      "scale": "1x"
+      "filename" : "Switch 24.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-48-poe.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-48-poe.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Switch 48 PoE.png",
-      "scale": "1x"
+      "filename" : "Switch 48 PoE.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-48.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-48.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Switch 48.png",
-      "scale": "1x"
+      "filename" : "Switch 48.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-aggregation.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-aggregation.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Switch Aggregation.png",
-      "scale": "1x"
+      "filename" : "Switch Aggregation.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-enterprise-8-poe-vintage.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-enterprise-8-poe-vintage.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Switch Enterprise 8 PoE (Vintage).png",
-      "scale": "1x"
+      "filename" : "Switch Enterprise 8 PoE (Vintage).png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-enterprise-audiovideo-fiber.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-enterprise-audiovideo-fiber.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Switch Enterprise AudioVideo Fiber.png",
-      "scale": "1x"
+      "filename" : "Switch Enterprise AudioVideo Fiber.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-enterprise-audiovideo-xg-24-poe.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-enterprise-audiovideo-xg-24-poe.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Switch Enterprise AudioVideo XG 24 PoE.png",
-      "scale": "1x"
+      "filename" : "Switch Enterprise AudioVideo XG 24 PoE.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-enterprise-campus-24-poe.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-enterprise-campus-24-poe.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Switch Enterprise Campus 24 PoE.png",
-      "scale": "1x"
+      "filename" : "Switch Enterprise Campus 24 PoE.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-enterprise-campus-24s-poe.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-enterprise-campus-24s-poe.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Switch Enterprise Campus 24S PoE.png",
-      "scale": "1x"
+      "filename" : "Switch Enterprise Campus 24S PoE.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-enterprise-campus-48-poe.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-enterprise-campus-48-poe.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Switch Enterprise Campus 48 PoE.png",
-      "scale": "1x"
+      "filename" : "Switch Enterprise Campus 48 PoE.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-enterprise-campus-48s-poe.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-enterprise-campus-48s-poe.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Switch Enterprise Campus 48S PoE.png",
-      "scale": "1x"
+      "filename" : "Switch Enterprise Campus 48S PoE.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-enterprise-campus-aggregation.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-enterprise-campus-aggregation.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Switch Enterprise Campus Aggregation.png",
-      "scale": "1x"
+      "filename" : "Switch Enterprise Campus Aggregation.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-flex-2-5g-poe.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-flex-2-5g-poe.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Switch Flex 2.5G PoE.png",
-      "scale": "1x"
+      "filename" : "Switch Flex 2.5G PoE.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-flex-2-5g.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-flex-2-5g.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Switch Flex 2.5G.png",
-      "scale": "1x"
+      "filename" : "Switch Flex 2.5G.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-flex-mini-2-5g.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-flex-mini-2-5g.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Switch Flex Mini 2.5G.png",
-      "scale": "1x"
+      "filename" : "Switch Flex Mini 2.5G.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-flex-mini.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-flex-mini.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Switch Flex Mini.png",
-      "scale": "1x"
+      "filename" : "Switch Flex Mini.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-flex-utility.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-flex-utility.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Switch Flex Utility.png",
-      "scale": "1x"
+      "filename" : "Switch Flex Utility.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-flex-xg.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-flex-xg.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Switch Flex XG.png",
-      "scale": "1x"
+      "filename" : "Switch Flex XG.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-flex.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-flex.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Switch Flex.png",
-      "scale": "1x"
+      "filename" : "Switch Flex.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-hi-capacity-aggregation.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-hi-capacity-aggregation.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Switch Hi-Capacity Aggregation.png",
-      "scale": "1x"
+      "filename" : "Switch Hi-Capacity Aggregation.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-lite-16-poe.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-lite-16-poe.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Switch Lite 16 PoE.png",
-      "scale": "1x"
+      "filename" : "Switch Lite 16 PoE.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-lite-8-poe.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-lite-8-poe.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Switch Lite 8 PoE.png",
-      "scale": "1x"
+      "filename" : "Switch Lite 8 PoE.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-pro-24-poe.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-pro-24-poe.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Switch Pro 24 PoE.png",
-      "scale": "1x"
+      "filename" : "Switch Pro 24 PoE.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-pro-24.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-pro-24.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Switch Pro 24.png",
-      "scale": "1x"
+      "filename" : "Switch Pro 24.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-pro-48-poe.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-pro-48-poe.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Switch Pro 48 PoE.png",
-      "scale": "1x"
+      "filename" : "Switch Pro 48 PoE.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-pro-48.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-pro-48.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Switch Pro 48.png",
-      "scale": "1x"
+      "filename" : "Switch Pro 48.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-pro-8-poe.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-pro-8-poe.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Switch Pro 8 PoE.png",
-      "scale": "1x"
+      "filename" : "Switch Pro 8 PoE.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-pro-hd-24-poe.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-pro-hd-24-poe.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Switch Pro HD 24 PoE.png",
-      "scale": "1x"
+      "filename" : "Switch Pro HD 24 PoE.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-pro-hd-24.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-pro-hd-24.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Switch Pro HD 24.png",
-      "scale": "1x"
+      "filename" : "Switch Pro HD 24.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-pro-max-16-poe.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-pro-max-16-poe.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Switch Pro Max 16 PoE.png",
-      "scale": "1x"
+      "filename" : "Switch Pro Max 16 PoE.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-pro-max-16.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-pro-max-16.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Switch Pro Max 16.png",
-      "scale": "1x"
+      "filename" : "Switch Pro Max 16.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-pro-max-24-poe.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-pro-max-24-poe.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Switch Pro Max 24 PoE.png",
-      "scale": "1x"
+      "filename" : "Switch Pro Max 24 PoE.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-pro-max-24.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-pro-max-24.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Switch Pro Max 24.png",
-      "scale": "1x"
+      "filename" : "Switch Pro Max 24.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-pro-max-48-poe.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-pro-max-48-poe.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Switch Pro Max 48 PoE.png",
-      "scale": "1x"
+      "filename" : "Switch Pro Max 48 PoE.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-pro-max-48.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-pro-max-48.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Switch Pro Max 48.png",
-      "scale": "1x"
+      "filename" : "Switch Pro Max 48.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-pro-xg-10-poe.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-pro-xg-10-poe.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Switch Pro XG 10 PoE.png",
-      "scale": "1x"
+      "filename" : "Switch Pro XG 10 PoE.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-pro-xg-24-poe.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-pro-xg-24-poe.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Switch Pro XG 24 PoE.png",
-      "scale": "1x"
+      "filename" : "Switch Pro XG 24 PoE.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-pro-xg-24.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-pro-xg-24.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Switch Pro XG 24.png",
-      "scale": "1x"
+      "filename" : "Switch Pro XG 24.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-pro-xg-48-poe.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-pro-xg-48-poe.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Switch Pro XG 48 PoE.png",
-      "scale": "1x"
+      "filename" : "Switch Pro XG 48 PoE.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-pro-xg-48.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-pro-xg-48.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Switch Pro XG 48.png",
-      "scale": "1x"
+      "filename" : "Switch Pro XG 48.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-pro-xg-8-poe.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-pro-xg-8-poe.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Switch Pro XG 8 PoE.png",
-      "scale": "1x"
+      "filename" : "Switch Pro XG 8 PoE.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-pro-xg-aggregation.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-switch-pro-xg-aggregation.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Switch Pro XG Aggregation.png",
-      "scale": "1x"
+      "filename" : "Switch Pro XG Aggregation.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-ultra.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-ultra.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "Ultra.png",
-      "scale": "1x"
+      "filename" : "Ultra.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-unifi-device-bridge.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-unifi-device-bridge.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "UniFi Device Bridge.png",
-      "scale": "1x"
+      "filename" : "UniFi Device Bridge.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-unifi-express-7.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-unifi-express-7.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "UniFi Express 7.png",
-      "scale": "1x"
+      "filename" : "UniFi Express 7.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-unifi-store-app-2.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-unifi-store-app-2.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "UniFi Store App_2.png",
-      "scale": "1x"
+      "filename" : "UniFi Store App_2.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-unifi-store-app-3.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-unifi-store-app-3.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "UniFi Store App_3.png",
-      "scale": "1x"
+      "filename" : "UniFi Store App_3.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-unifi-store-app.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-unifi-store-app.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "UniFi Store App.png",
-      "scale": "1x"
+      "filename" : "UniFi Store App.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-unifi-travel-router.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-unifi-travel-router.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "UniFi Travel Router.png",
-      "scale": "1x"
+      "filename" : "UniFi Travel Router.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-unifi-wan-switch-rj45.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-unifi-wan-switch-rj45.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "UniFi WAN Switch RJ45.png",
-      "scale": "1x"
+      "filename" : "UniFi WAN Switch RJ45.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-unifi-wan-switch.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-unifi-wan-switch.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "UniFi WAN Switch.png",
-      "scale": "1x"
+      "filename" : "UniFi WAN Switch.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-ups-poe-switch-mission-critical.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-ups-poe-switch-mission-critical.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "UPS PoE Switch Mission Critical.png",
-      "scale": "1x"
+      "filename" : "UPS PoE Switch Mission Critical.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-wifi-basestation-xg.imageset/Contents.json
+++ b/HomelabSwift/Homelab/Assets.xcassets/ubiquiti-device-wifi-basestation-xg.imageset/Contents.json
@@ -1,13 +1,21 @@
 {
-  "images": [
+  "images" : [
     {
-      "idiom": "universal",
-      "filename": "WiFi BaseStation XG.png",
-      "scale": "1x"
+      "filename" : "WiFi BaseStation XG.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/HomelabSwift/Homelab/Localization/Translations+English.swift
+++ b/HomelabSwift/Homelab/Localization/Translations+English.swift
@@ -1554,6 +1554,39 @@ extension Translations {
         proxmoxConfigSaved: "Configuration saved",
         proxmoxConfigSaveError: "Failed to save configuration",
         debugLogsEmpty: "No logs yet",
-        securityLockoutMessage: "Too many attempts. Wait %d seconds."
+        securityLockoutMessage: "Too many attempts. Wait %d seconds.",
+
+        // Pterodactyl
+        servicePterodactylDesc: "Game server management panel",
+        loginHintPterodactyl: "Use a Pterodactyl Client API key. Generate one from your account page under API Credentials.",
+        pterodactylNoServers: "No servers found for this account.",
+        pterodactylRunningServers: "Running servers",
+        pterodactylTotalServers: "Total servers",
+        pterodactylCPU: "CPU",
+        pterodactylRAM: "RAM",
+        pterodactylDisk: "Disk",
+        pterodactylUptime: "Uptime",
+        pterodactylStatusRunning: "Running",
+        pterodactylStatusStopping: "Stopping",
+        pterodactylStatusStarting: "Starting",
+        pterodactylStatusOffline: "Offline",
+        pterodactylStatusSuspended: "Suspended",
+        pterodactylStatusInstalling: "Installing",
+
+        // Calagopus
+        serviceCalagopusDesc: "Next-generation game server management panel",
+        loginHintCalagopus: "Use a Calagopus Client API key. Generate one from your account page under API Credentials.",
+        calagopusNoServers: "No servers found for this account.",
+        calagopusRunningServers: "Running servers",
+        calagopusTotalServers: "Total servers",
+        calagopusCPU: "CPU",
+        calagopusRAM: "RAM",
+        calagopusDisk: "Disk",
+        calagopusUptime: "Uptime",
+        calagopusStatusRunning: "Running",
+        calagopusStatusStopping: "Stopping",
+        calagopusStatusStarting: "Starting",
+        calagopusStatusOffline: "Offline",
+        calagopusStatusSuspended: "Suspended"
     )
 }

--- a/HomelabSwift/Homelab/Localization/Translations+French.swift
+++ b/HomelabSwift/Homelab/Localization/Translations+French.swift
@@ -1556,6 +1556,39 @@ extension Translations {
         proxmoxConfigSaved: "Configuration enregistrée",
         proxmoxConfigSaveError: "Échec de l'enregistrement de la configuration",
         debugLogsEmpty: "Aucun log pour l'instant",
-        securityLockoutMessage: "Trop de tentatives. Attendez %d secondes."
+        securityLockoutMessage: "Trop de tentatives. Attendez %d secondes.",
+
+        // Pterodactyl
+        servicePterodactylDesc: "Panneau de gestion de serveurs de jeux",
+        loginHintPterodactyl: "Utilisez une clé API Client Pterodactyl. Générez-la depuis votre page de compte sous Identifiants API.",
+        pterodactylNoServers: "Aucun serveur trouvé pour ce compte.",
+        pterodactylRunningServers: "Serveurs actifs",
+        pterodactylTotalServers: "Serveurs au total",
+        pterodactylCPU: "CPU",
+        pterodactylRAM: "RAM",
+        pterodactylDisk: "Disque",
+        pterodactylUptime: "Disponibilité",
+        pterodactylStatusRunning: "En cours",
+        pterodactylStatusStopping: "Arrêt en cours",
+        pterodactylStatusStarting: "Démarrage",
+        pterodactylStatusOffline: "Hors ligne",
+        pterodactylStatusSuspended: "Suspendu",
+        pterodactylStatusInstalling: "Installation",
+
+        // Calagopus
+        serviceCalagopusDesc: "Panneau de gestion de serveurs de jeux nouvelle génération",
+        loginHintCalagopus: "Utilisez une clé API Client Calagopus. Générez-en une depuis votre page de compte sous Identifiants API.",
+        calagopusNoServers: "Aucun serveur trouvé pour ce compte.",
+        calagopusRunningServers: "Serveurs actifs",
+        calagopusTotalServers: "Serveurs totaux",
+        calagopusCPU: "CPU",
+        calagopusRAM: "RAM",
+        calagopusDisk: "Disque",
+        calagopusUptime: "Disponibilité",
+        calagopusStatusRunning: "En cours",
+        calagopusStatusStopping: "Arrêt en cours",
+        calagopusStatusStarting: "Démarrage",
+        calagopusStatusOffline: "Hors ligne",
+        calagopusStatusSuspended: "Suspendu"
     )
 }

--- a/HomelabSwift/Homelab/Localization/Translations+German.swift
+++ b/HomelabSwift/Homelab/Localization/Translations+German.swift
@@ -1556,6 +1556,39 @@ extension Translations {
         proxmoxConfigSaved: "Konfiguration gespeichert",
         proxmoxConfigSaveError: "Konfiguration konnte nicht gespeichert werden",
         debugLogsEmpty: "Noch keine Logs",
-        securityLockoutMessage: "Zu viele Versuche. Warten Sie %d Sekunden."
+        securityLockoutMessage: "Zu viele Versuche. Warten Sie %d Sekunden.",
+
+        // Pterodactyl
+        servicePterodactylDesc: "Game-Server-Verwaltungspanel",
+        loginHintPterodactyl: "Verwende einen Pterodactyl Client-API-Schlüssel. Erstelle einen auf deiner Kontoseite unter API-Zugangsdaten.",
+        pterodactylNoServers: "Keine Server für dieses Konto gefunden.",
+        pterodactylRunningServers: "Laufende Server",
+        pterodactylTotalServers: "Server insgesamt",
+        pterodactylCPU: "CPU",
+        pterodactylRAM: "RAM",
+        pterodactylDisk: "Festplatte",
+        pterodactylUptime: "Laufzeit",
+        pterodactylStatusRunning: "Läuft",
+        pterodactylStatusStopping: "Wird gestoppt",
+        pterodactylStatusStarting: "Wird gestartet",
+        pterodactylStatusOffline: "Offline",
+        pterodactylStatusSuspended: "Gesperrt",
+        pterodactylStatusInstalling: "Wird installiert",
+
+        // Calagopus
+        serviceCalagopusDesc: "Spielserver-Verwaltungspanel der nächsten Generation",
+        loginHintCalagopus: "Verwende einen Calagopus Client-API-Schlüssel. Erstelle ihn auf deiner Kontoseite unter API-Anmeldedaten.",
+        calagopusNoServers: "Keine Server für dieses Konto gefunden.",
+        calagopusRunningServers: "Aktive Server",
+        calagopusTotalServers: "Server gesamt",
+        calagopusCPU: "CPU",
+        calagopusRAM: "RAM",
+        calagopusDisk: "Festplatte",
+        calagopusUptime: "Laufzeit",
+        calagopusStatusRunning: "Läuft",
+        calagopusStatusStopping: "Wird gestoppt",
+        calagopusStatusStarting: "Wird gestartet",
+        calagopusStatusOffline: "Offline",
+        calagopusStatusSuspended: "Gesperrt"
     )
 }

--- a/HomelabSwift/Homelab/Localization/Translations+Italian.swift
+++ b/HomelabSwift/Homelab/Localization/Translations+Italian.swift
@@ -1554,6 +1554,39 @@ extension Translations {
         proxmoxConfigSaved: "Configurazione salvata",
         proxmoxConfigSaveError: "Impossibile salvare la configurazione",
         debugLogsEmpty: "Nessun log presente",
-        securityLockoutMessage: "Troppi tentativi. Attendi %d secondi."
+        securityLockoutMessage: "Troppi tentativi. Attendi %d secondi.",
+
+        // Pterodactyl
+        servicePterodactylDesc: "Pannello di gestione server di gioco",
+        loginHintPterodactyl: "Usa una chiave API Client di Pterodactyl. Generala dalla tua pagina account sotto Credenziali API.",
+        pterodactylNoServers: "Nessun server trovato per questo account.",
+        pterodactylRunningServers: "Server attivi",
+        pterodactylTotalServers: "Server totali",
+        pterodactylCPU: "CPU",
+        pterodactylRAM: "RAM",
+        pterodactylDisk: "Disco",
+        pterodactylUptime: "Uptime",
+        pterodactylStatusRunning: "Attivo",
+        pterodactylStatusStopping: "In arresto",
+        pterodactylStatusStarting: "In avvio",
+        pterodactylStatusOffline: "Offline",
+        pterodactylStatusSuspended: "Sospeso",
+        pterodactylStatusInstalling: "In installazione",
+
+        // Calagopus
+        serviceCalagopusDesc: "Pannello di gestione server di gioco di nuova generazione",
+        loginHintCalagopus: "Usa una chiave API Client di Calagopus. Generala dalla tua pagina account sotto Credenziali API.",
+        calagopusNoServers: "Nessun server trovato per questo account.",
+        calagopusRunningServers: "Server attivi",
+        calagopusTotalServers: "Server totali",
+        calagopusCPU: "CPU",
+        calagopusRAM: "RAM",
+        calagopusDisk: "Disco",
+        calagopusUptime: "Uptime",
+        calagopusStatusRunning: "Attivo",
+        calagopusStatusStopping: "In arresto",
+        calagopusStatusStarting: "In avvio",
+        calagopusStatusOffline: "Offline",
+        calagopusStatusSuspended: "Sospeso"
     )
 }

--- a/HomelabSwift/Homelab/Localization/Translations+Spanish.swift
+++ b/HomelabSwift/Homelab/Localization/Translations+Spanish.swift
@@ -1556,6 +1556,39 @@ extension Translations {
         proxmoxConfigSaved: "Configuración guardada",
         proxmoxConfigSaveError: "Error al guardar la configuración",
         debugLogsEmpty: "Aún no hay registros",
-        securityLockoutMessage: "Demasiados intentos. Espera %d segundos."
+        securityLockoutMessage: "Demasiados intentos. Espera %d segundos.",
+
+        // Pterodactyl
+        servicePterodactylDesc: "Panel de gestión de servidores de juegos",
+        loginHintPterodactyl: "Usa una clave API de cliente de Pterodactyl. Genera una desde la página de tu cuenta en Credenciales de API.",
+        pterodactylNoServers: "No se encontraron servidores para esta cuenta.",
+        pterodactylRunningServers: "Servidores activos",
+        pterodactylTotalServers: "Servidores totales",
+        pterodactylCPU: "CPU",
+        pterodactylRAM: "RAM",
+        pterodactylDisk: "Disco",
+        pterodactylUptime: "Tiempo activo",
+        pterodactylStatusRunning: "En ejecución",
+        pterodactylStatusStopping: "Deteniéndose",
+        pterodactylStatusStarting: "Iniciando",
+        pterodactylStatusOffline: "Sin conexión",
+        pterodactylStatusSuspended: "Suspendido",
+        pterodactylStatusInstalling: "Instalando",
+
+        // Calagopus
+        serviceCalagopusDesc: "Panel de gestión de servidores de juegos de nueva generación",
+        loginHintCalagopus: "Usa una clave API Client de Calagopus. Genérala desde tu página de cuenta en Credenciales API.",
+        calagopusNoServers: "No se encontraron servidores para esta cuenta.",
+        calagopusRunningServers: "Servidores activos",
+        calagopusTotalServers: "Servidores totales",
+        calagopusCPU: "CPU",
+        calagopusRAM: "RAM",
+        calagopusDisk: "Disco",
+        calagopusUptime: "Tiempo activo",
+        calagopusStatusRunning: "En ejecución",
+        calagopusStatusStopping: "Deteniéndose",
+        calagopusStatusStarting: "Iniciando",
+        calagopusStatusOffline: "Sin conexión",
+        calagopusStatusSuspended: "Suspendido"
     )
 }

--- a/HomelabSwift/Homelab/Localization/Translations.swift
+++ b/HomelabSwift/Homelab/Localization/Translations.swift
@@ -1626,6 +1626,39 @@ struct Translations {
 
     let debugLogsEmpty: String
     let securityLockoutMessage: String
+
+    // Pterodactyl
+    let servicePterodactylDesc: String
+    let loginHintPterodactyl: String
+    let pterodactylNoServers: String
+    let pterodactylRunningServers: String
+    let pterodactylTotalServers: String
+    let pterodactylCPU: String
+    let pterodactylRAM: String
+    let pterodactylDisk: String
+    let pterodactylUptime: String
+    let pterodactylStatusRunning: String
+    let pterodactylStatusStopping: String
+    let pterodactylStatusStarting: String
+    let pterodactylStatusOffline: String
+    let pterodactylStatusSuspended: String
+    let pterodactylStatusInstalling: String
+
+    // Calagopus
+    let serviceCalagopusDesc: String
+    let loginHintCalagopus: String
+    let calagopusNoServers: String
+    let calagopusRunningServers: String
+    let calagopusTotalServers: String
+    let calagopusCPU: String
+    let calagopusRAM: String
+    let calagopusDisk: String
+    let calagopusUptime: String
+    let calagopusStatusRunning: String
+    let calagopusStatusStopping: String
+    let calagopusStatusStarting: String
+    let calagopusStatusOffline: String
+    let calagopusStatusSuspended: String
 }
 
 // MARK: - Factory

--- a/HomelabSwift/Homelab/Models/ServiceType.swift
+++ b/HomelabSwift/Homelab/Models/ServiceType.swift
@@ -32,6 +32,8 @@ public enum ServiceType: String, CaseIterable, Identifiable, Codable, Hashable, 
     case flaresolverr
     case wakapi
     case proxmox
+    case pterodactyl
+    case calagopus
 
     public var id: String { rawValue }
 
@@ -74,6 +76,10 @@ public enum ServiceType: String, CaseIterable, Identifiable, Codable, Hashable, 
             return .unifiNetwork
         case "proxmox", "proxmox_ve", "proxmoxve", "pve":
             return .proxmox
+        case "pterodactyl":
+            return .pterodactyl
+        case "calagopus":
+            return .calagopus
         default:
             return nil
         }
@@ -149,6 +155,8 @@ public enum ServiceType: String, CaseIterable, Identifiable, Codable, Hashable, 
         case .flaresolverr:       return "FlareSolverr"
         case .wakapi:             return "Wakapi"
         case .proxmox:            return "Proxmox VE"
+        case .pterodactyl:        return "Pterodactyl"
+        case .calagopus:          return "Calagopus"
         }
     }
 
@@ -185,6 +193,8 @@ public enum ServiceType: String, CaseIterable, Identifiable, Codable, Hashable, 
         case .flaresolverr:       return t.serviceFlaresolverrDesc
         case .wakapi:             return t.serviceWakapiDesc
         case .proxmox:            return t.serviceProxmoxDesc
+        case .pterodactyl:        return t.servicePterodactylDesc
+        case .calagopus:          return t.serviceCalagopusDesc
         }
     }
 
@@ -226,6 +236,8 @@ public enum ServiceType: String, CaseIterable, Identifiable, Codable, Hashable, 
         case .flaresolverr:       return "flame.fill"
         case .wakapi:             return "timer"
         case .proxmox:            return "cpu"
+        case .pterodactyl:        return "gamecontroller.fill"
+        case .calagopus:          return "bird.fill"
         }
     }
 
@@ -262,6 +274,8 @@ public enum ServiceType: String, CaseIterable, Identifiable, Codable, Hashable, 
         case .flaresolverr:       return "https://cdn.jsdelivr.net/gh/selfhst/icons/png/flaresolverr.png"
         case .wakapi:             return "https://cdn.jsdelivr.net/gh/selfhst/icons/png/wakapi.png"
         case .proxmox:            return "https://cdn.jsdelivr.net/gh/selfhst/icons/png/proxmox.png"
+        case .pterodactyl:        return "https://cdn.jsdelivr.net/gh/selfhst/icons/png/pterodactyl.png"
+        case .calagopus:          return "https://cdn.jsdelivr.net/gh/selfhst/icons/png/calagopus.png"
         }
     }
 
@@ -299,6 +313,8 @@ public enum ServiceType: String, CaseIterable, Identifiable, Codable, Hashable, 
         case .flaresolverr:       slug = "flaresolverr"
         case .wakapi:             slug = "wakapi"
         case .proxmox:            slug = "proxmox"
+        case .pterodactyl:        slug = "pterodactyl"
+        case .calagopus:          slug = "calagopus"
         }
         var orderedCandidates: [String] = []
         let primary = iconUrl.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -350,6 +366,8 @@ public enum ServiceType: String, CaseIterable, Identifiable, Codable, Hashable, 
         case .flaresolverr:       return "service-flaresolverr"
         case .wakapi:             return "service-wakapi"
         case .proxmox:            return "service-proxmox"
+        case .pterodactyl:        return "service-pterodactyl"
+        case .calagopus:          return "service-calagopus"
         }
     }
 
@@ -386,6 +404,8 @@ public enum ServiceType: String, CaseIterable, Identifiable, Codable, Hashable, 
         case .flaresolverr:       return ServiceColorSet(primary: Color(hex: "#FF4500"), dark: Color(hex: "#CC3700"), bg: Color(hex: "#FF4500").opacity(0.09))
         case .wakapi:             return ServiceColorSet(primary: Color(hex: "#2563EB"), dark: Color(hex: "#1D4ED8"), bg: Color(hex: "#2563EB").opacity(0.09))
         case .proxmox:            return ServiceColorSet(primary: Color(hex: "#D97706"), dark: Color(hex: "#B45309"), bg: Color(hex: "#D97706").opacity(0.06))
+        case .pterodactyl:        return ServiceColorSet(primary: Color(hex: "#0E4BEF"), dark: Color(hex: "#0B38C5"), bg: Color(hex: "#0E4BEF").opacity(0.09))
+        case .calagopus:          return ServiceColorSet(primary: Color(hex: "#16A34A"), dark: Color(hex: "#15803D"), bg: Color(hex: "#16A34A").opacity(0.09))
         }
     }
 }

--- a/HomelabSwift/Homelab/Networking/Calagopus/CalagopusAPIClient.swift
+++ b/HomelabSwift/Homelab/Networking/Calagopus/CalagopusAPIClient.swift
@@ -1,0 +1,202 @@
+import Foundation
+
+// MARK: - Models
+
+struct CalagopusServerList: Codable {
+    let servers: CalagopusServerPage
+}
+
+struct CalagopusServerPage: Codable {
+    let total: Int
+    let perPage: Int
+    let page: Int
+    let data: [CalagopusServer]
+
+    enum CodingKeys: String, CodingKey {
+        case total, page, data
+        case perPage = "per_page"
+    }
+}
+
+struct CalagopusServer: Codable, Identifiable, Hashable {
+    let uuid: String
+    let uuidShort: String
+    let name: String
+    let description: String?
+    let status: String?
+    let isSuspended: Bool
+    let isOwner: Bool
+    let nodeName: String
+    let locationName: String
+    let limits: CalagopusLimits
+
+    var id: String { uuidShort }
+
+    enum CodingKeys: String, CodingKey {
+        case uuid, name, description, status, limits
+        case uuidShort = "uuid_short"
+        case isSuspended = "is_suspended"
+        case isOwner = "is_owner"
+        case nodeName = "node_name"
+        case locationName = "location_name"
+    }
+}
+
+struct CalagopusLimits: Codable, Hashable {
+    let memory: Int
+    let disk: Int
+    let cpu: Int
+    let swap: Int
+}
+
+struct CalagopusResourcesResponse: Codable {
+    let resources: CalagopusResources
+}
+
+struct CalagopusResources: Codable, Hashable {
+    let state: String
+    let memoryBytes: Int
+    let memoryLimitBytes: Int
+    let diskBytes: Int
+    let cpuAbsolute: Double
+    let uptime: Int
+    let network: CalagopusNetwork
+
+    enum CodingKeys: String, CodingKey {
+        case state, uptime, network
+        case memoryBytes = "memory_bytes"
+        case memoryLimitBytes = "memory_limit_bytes"
+        case diskBytes = "disk_bytes"
+        case cpuAbsolute = "cpu_absolute"
+    }
+}
+
+struct CalagopusNetwork: Codable, Hashable {
+    let rxBytes: Int
+    let txBytes: Int
+
+    enum CodingKeys: String, CodingKey {
+        case rxBytes = "rx_bytes"
+        case txBytes = "tx_bytes"
+    }
+}
+
+enum CalagopusPowerSignal: String {
+    case start, stop, restart, kill
+}
+
+// MARK: - API Client
+
+actor CalagopusAPIClient {
+    private let instanceId: UUID
+    private var engine: BaseNetworkEngine
+    private var storedAllowSelfSigned = true
+    private var baseURL: String = ""
+    private var fallbackURL: String = ""
+    private var apiKey: String = ""
+
+    init(instanceId: UUID) {
+        self.instanceId = instanceId
+        self.engine = BaseNetworkEngine(serviceType: .calagopus, instanceId: instanceId)
+    }
+
+    // MARK: - Configuration
+
+    func configure(url: String, apiKey: String, fallbackUrl: String? = nil, allowSelfSigned: Bool? = nil) {
+        self.baseURL = Self.cleanURL(url)
+        self.fallbackURL = Self.cleanURL(fallbackUrl ?? "")
+        self.apiKey = apiKey
+        if let allowSelfSigned {
+            storedAllowSelfSigned = allowSelfSigned
+        }
+        engine = BaseNetworkEngine(serviceType: .calagopus, instanceId: self.instanceId, allowSelfSigned: self.storedAllowSelfSigned)
+    }
+
+    // MARK: - Auth headers
+
+    private func authHeaders() -> [String: String] {
+        [
+            "Authorization": "Bearer \(apiKey)",
+            "Accept": "application/json",
+            "Content-Type": "application/json"
+        ]
+    }
+
+    // MARK: - Ping
+
+    func ping() async -> Bool {
+        guard !baseURL.isEmpty else { return false }
+        let primary = await engine.pingURL(
+            "\(baseURL)/api/client/servers",
+            extraHeaders: authHeaders()
+        )
+        if primary { return true }
+        guard !fallbackURL.isEmpty else { return false }
+        return await engine.pingURL(
+            "\(fallbackURL)/api/client/servers",
+            extraHeaders: authHeaders()
+        )
+    }
+
+    // MARK: - Validation (used at login)
+
+    func authenticate(url: String, apiKey: String, fallbackUrl: String? = nil) async throws {
+        let cleanURL = Self.cleanURL(url)
+        let headers = [
+            "Authorization": "Bearer \(apiKey)",
+            "Accept": "application/json",
+            "Content-Type": "application/json"
+        ]
+        let _: CalagopusServerList = try await engine.request(
+            baseURL: cleanURL,
+            fallbackURL: Self.cleanURL(fallbackUrl ?? ""),
+            path: "/api/client/servers",
+            headers: headers
+        )
+    }
+
+    // MARK: - Servers
+
+    func getServers() async throws -> [CalagopusServer] {
+        let response: CalagopusServerList = try await engine.request(
+            baseURL: baseURL,
+            fallbackURL: fallbackURL,
+            path: "/api/client/servers",
+            headers: authHeaders()
+        )
+        return response.servers.data
+    }
+
+    func getServerResources(uuidShort: String) async throws -> CalagopusResources {
+        let response: CalagopusResourcesResponse = try await engine.request(
+            baseURL: baseURL,
+            fallbackURL: fallbackURL,
+            path: "/api/client/servers/\(uuidShort)/resources",
+            headers: authHeaders()
+        )
+        return response.resources
+    }
+
+    // MARK: - Power actions
+
+    func sendPowerSignal(uuidShort: String, signal: CalagopusPowerSignal) async throws {
+        struct PowerBody: Encodable { let signal: String }
+        let body = try JSONEncoder().encode(PowerBody(signal: signal.rawValue))
+        try await engine.requestVoid(
+            baseURL: baseURL,
+            fallbackURL: fallbackURL,
+            path: "/api/client/servers/\(uuidShort)/power",
+            method: "POST",
+            headers: authHeaders(),
+            body: body
+        )
+    }
+
+    // MARK: - Helpers
+
+    private static func cleanURL(_ url: String) -> String {
+        var s = url.trimmingCharacters(in: .whitespacesAndNewlines)
+        while s.hasSuffix("/") { s = String(s.dropLast()) }
+        return s
+    }
+}

--- a/HomelabSwift/Homelab/Networking/Pterodactyl/PterodactylAPIClient.swift
+++ b/HomelabSwift/Homelab/Networking/Pterodactyl/PterodactylAPIClient.swift
@@ -1,0 +1,194 @@
+import Foundation
+
+// MARK: - Models
+
+struct PterodactylServerList: Codable {
+    let data: [PterodactylServerEntry]
+}
+
+struct PterodactylServerEntry: Codable {
+    let attributes: PterodactylServer
+}
+
+struct PterodactylServer: Codable, Identifiable, Hashable {
+    let identifier: String
+    let uuid: String
+    let name: String
+    let node: String
+    let description: String
+    let isNodeUnderMaintenance: Bool
+    let status: String?
+    let isSuspended: Bool
+    let isInstalling: Bool
+    let limits: PterodactylLimits
+
+    var id: String { identifier }
+
+    enum CodingKeys: String, CodingKey {
+        case identifier, uuid, name, node, description, status, limits
+        case isNodeUnderMaintenance = "is_node_under_maintenance"
+        case isSuspended = "is_suspended"
+        case isInstalling = "is_installing"
+    }
+}
+
+struct PterodactylLimits: Codable, Hashable {
+    let memory: Int
+    let disk: Int
+    let cpu: Int
+}
+
+struct PterodactylResourcesResponse: Codable {
+    let attributes: PterodactylResources
+}
+
+struct PterodactylResources: Codable, Hashable {
+    let currentState: String
+    let isSuspended: Bool
+    let resources: PterodactylResourceUsage
+
+    enum CodingKeys: String, CodingKey {
+        case isSuspended = "is_suspended"
+        case currentState = "current_state"
+        case resources
+    }
+}
+
+struct PterodactylResourceUsage: Codable, Hashable {
+    let memoryBytes: Int
+    let cpuAbsolute: Double
+    let diskBytes: Int
+    let networkRxBytes: Int
+    let networkTxBytes: Int
+    let uptime: Int
+
+    enum CodingKeys: String, CodingKey {
+        case memoryBytes = "memory_bytes"
+        case cpuAbsolute = "cpu_absolute"
+        case diskBytes = "disk_bytes"
+        case networkRxBytes = "network_rx_bytes"
+        case networkTxBytes = "network_tx_bytes"
+        case uptime
+    }
+}
+
+enum PterodactylPowerSignal: String {
+    case start, stop, restart, kill
+}
+
+// MARK: - API Client
+
+actor PterodactylAPIClient {
+    private let instanceId: UUID
+    private var engine: BaseNetworkEngine
+    private var storedAllowSelfSigned = true
+    private var baseURL: String = ""
+    private var fallbackURL: String = ""
+    private var apiKey: String = ""
+
+    init(instanceId: UUID) {
+        self.instanceId = instanceId
+        self.engine = BaseNetworkEngine(serviceType: .pterodactyl, instanceId: instanceId)
+    }
+
+    // MARK: - Configuration
+
+    func configure(url: String, apiKey: String, fallbackUrl: String? = nil, allowSelfSigned: Bool? = nil) {
+        self.baseURL = Self.cleanURL(url)
+        self.fallbackURL = Self.cleanURL(fallbackUrl ?? "")
+        self.apiKey = apiKey
+
+        if let allowSelfSigned {
+            storedAllowSelfSigned = allowSelfSigned
+        }
+        engine = BaseNetworkEngine(serviceType: .pterodactyl, instanceId: self.instanceId, allowSelfSigned: self.storedAllowSelfSigned)
+    }
+
+    // MARK: - Auth headers
+
+    private func authHeaders() -> [String: String] {
+        [
+            "Authorization": "Bearer \(apiKey)",
+            "Accept": "application/json",
+            "Content-Type": "application/json"
+        ]
+    }
+
+    // MARK: - Ping
+
+    func ping() async -> Bool {
+        guard !baseURL.isEmpty else { return false }
+        let primary = await engine.pingURL(
+            "\(baseURL)/api/client",
+            extraHeaders: authHeaders()
+        )
+        if primary { return true }
+        guard !fallbackURL.isEmpty else { return false }
+        return await engine.pingURL(
+            "\(fallbackURL)/api/client",
+            extraHeaders: authHeaders()
+        )
+    }
+
+    // MARK: - Validation (used at login)
+
+    func authenticate(url: String, apiKey: String, fallbackUrl: String? = nil) async throws {
+        let cleanURL = Self.cleanURL(url)
+        let headers = [
+            "Authorization": "Bearer \(apiKey)",
+            "Accept": "application/json",
+            "Content-Type": "application/json"
+        ]
+        let _: PterodactylServerList = try await engine.request(
+            baseURL: cleanURL,
+            fallbackURL: Self.cleanURL(fallbackUrl ?? ""),
+            path: "/api/client",
+            headers: headers
+        )
+    }
+
+    // MARK: - Servers
+
+    func getServers() async throws -> [PterodactylServer] {
+        let response: PterodactylServerList = try await engine.request(
+            baseURL: baseURL,
+            fallbackURL: fallbackURL,
+            path: "/api/client",
+            headers: authHeaders()
+        )
+        return response.data.map(\.attributes)
+    }
+
+    func getServerResources(identifier: String) async throws -> PterodactylResources {
+        let response: PterodactylResourcesResponse = try await engine.request(
+            baseURL: baseURL,
+            fallbackURL: fallbackURL,
+            path: "/api/client/servers/\(identifier)/resources",
+            headers: authHeaders()
+        )
+        return response.attributes
+    }
+
+    // MARK: - Power actions
+
+    func sendPowerSignal(identifier: String, signal: PterodactylPowerSignal) async throws {
+        struct PowerBody: Encodable { let signal: String }
+        let body = try JSONEncoder().encode(PowerBody(signal: signal.rawValue))
+        try await engine.requestVoid(
+            baseURL: baseURL,
+            fallbackURL: fallbackURL,
+            path: "/api/client/servers/\(identifier)/power",
+            method: "POST",
+            headers: authHeaders(),
+            body: body
+        )
+    }
+
+    // MARK: - Helpers
+
+    private static func cleanURL(_ url: String) -> String {
+        var s = url.trimmingCharacters(in: .whitespacesAndNewlines)
+        while s.hasSuffix("/") { s = String(s.dropLast()) }
+        return s
+    }
+}

--- a/HomelabSwift/Homelab/Services/BackupModels.swift
+++ b/HomelabSwift/Homelab/Services/BackupModels.swift
@@ -69,6 +69,8 @@ enum BackupServiceTypeMapper {
         case .flaresolverr:      return "flaresolverr"
         case .wakapi:            return "wakapi"
         case .proxmox:           return "proxmox"
+        case .pterodactyl:       return "pterodactyl"
+        case .calagopus:         return "calagopus"
         }
     }
 
@@ -123,6 +125,8 @@ enum BackupServiceTypeMapper {
         case "proxmox",
              "proxmox_ve",
              "pve":                  return .proxmox
+        case "pterodactyl":          return .pterodactyl
+        case "calagopus":            return .calagopus
         default:                     return nil
         }
     }

--- a/HomelabSwift/Homelab/Stores/ServicesStore.swift
+++ b/HomelabSwift/Homelab/Stores/ServicesStore.swift
@@ -30,6 +30,8 @@ private final class ServiceClientManager {
     private var genericClients: [UUID: GenericAPIClient] = [:]
     private var wakapiClients: [UUID: WakapiAPIClient] = [:]
     private var proxmoxClients: [UUID: ProxmoxAPIClient] = [:]
+    private var pterodactylClients: [UUID: PterodactylAPIClient] = [:]
+    private var calagopusClients: [UUID: CalagopusAPIClient] = [:]
 
     func portainerClient(id: UUID) -> PortainerAPIClient {
         if let client = portainerClients[id] {
@@ -264,6 +266,24 @@ private final class ServiceClientManager {
         return client
     }
 
+    func pterodactylClient(id: UUID) -> PterodactylAPIClient {
+        if let client = pterodactylClients[id] {
+            return client
+        }
+        let client = PterodactylAPIClient(instanceId: id)
+        pterodactylClients[id] = client
+        return client
+    }
+
+    func calagopusClient(id: UUID) -> CalagopusAPIClient {
+        if let client = calagopusClients[id] {
+            return client
+        }
+        let client = CalagopusAPIClient(instanceId: id)
+        calagopusClients[id] = client
+        return client
+    }
+
     func genericClient(id: UUID, type: ServiceType) -> GenericAPIClient {
         if let client = genericClients[id] {
             return client
@@ -327,6 +347,10 @@ private final class ServiceClientManager {
             wakapiClients.removeValue(forKey: id)
         case .proxmox:
             proxmoxClients.removeValue(forKey: id)
+        case .pterodactyl:
+            pterodactylClients.removeValue(forKey: id)
+        case .calagopus:
+            calagopusClients.removeValue(forKey: id)
         case .jellyseerr, .prowlarr, .bazarr, .gluetun, .flaresolverr:
             genericClients.removeValue(forKey: id)
         }
@@ -361,6 +385,8 @@ private final class ServiceClientManager {
         lidarrClients = lidarrClients.filter { knownInstanceIds.contains($0.key) }
         wakapiClients = wakapiClients.filter { knownInstanceIds.contains($0.key) }
         proxmoxClients = proxmoxClients.filter { knownInstanceIds.contains($0.key) }
+        pterodactylClients = pterodactylClients.filter { knownInstanceIds.contains($0.key) }
+        calagopusClients = calagopusClients.filter { knownInstanceIds.contains($0.key) }
         genericClients = genericClients.filter { knownInstanceIds.contains($0.key) }
     }
 }
@@ -693,6 +719,16 @@ final class ServicesStore {
         return clientManager.proxmoxClient(id: instance.id)
     }
 
+    func pterodactylClient(instanceId: UUID) async -> PterodactylAPIClient? {
+        guard let instance = instancesById[instanceId], instance.type == .pterodactyl else { return nil }
+        return clientManager.pterodactylClient(id: instance.id)
+    }
+
+    func calagopusClient(instanceId: UUID) async -> CalagopusAPIClient? {
+        guard let instance = instancesById[instanceId], instance.type == .calagopus else { return nil }
+        return clientManager.calagopusClient(id: instance.id)
+    }
+
     func genericMediaClient(instanceId: UUID) async -> GenericAPIClient? {
         guard let instance = instancesById[instanceId],
               [.jellyseerr, .prowlarr, .bazarr, .gluetun, .flaresolverr].contains(instance.type) else {
@@ -762,6 +798,10 @@ final class ServicesStore {
             ok = await clientManager.wakapiClient(id: instanceId).ping()
         case .proxmox:
             ok = await clientManager.proxmoxClient(id: instanceId).ping()
+        case .pterodactyl:
+            ok = await clientManager.pterodactylClient(id: instanceId).ping()
+        case .calagopus:
+            ok = await clientManager.calagopusClient(id: instanceId).ping()
         case .jellyseerr, .prowlarr, .bazarr, .gluetun, .flaresolverr:
             ok = await clientManager.genericClient(id: instanceId, type: instance.type).ping()
         }
@@ -1210,6 +1250,24 @@ final class ServicesStore {
         case .jellyseerr, .prowlarr, .bazarr, .gluetun, .flaresolverr:
             let client = clientManager.genericClient(id: instance.id, type: instance.type)
             await client.configure(url: instance.url, fallbackUrl: instance.fallbackUrl, apiKey: instance.apiKey, allowSelfSigned: instance.allowSelfSigned)
+
+        case .pterodactyl:
+            let client = clientManager.pterodactylClient(id: instance.id)
+            await client.configure(
+                url: instance.url,
+                apiKey: instance.apiKey ?? "",
+                fallbackUrl: instance.fallbackUrl,
+                allowSelfSigned: instance.allowSelfSigned
+            )
+
+        case .calagopus:
+            let client = clientManager.calagopusClient(id: instance.id)
+            await client.configure(
+                url: instance.url,
+                apiKey: instance.apiKey ?? "",
+                fallbackUrl: instance.fallbackUrl,
+                allowSelfSigned: instance.allowSelfSigned
+            )
 
         case .proxmox:
             let client = clientManager.proxmoxClient(id: instance.id)

--- a/HomelabSwift/Homelab/Views/Calagopus/CalagopusDashboard.swift
+++ b/HomelabSwift/Homelab/Views/Calagopus/CalagopusDashboard.swift
@@ -1,0 +1,439 @@
+import SwiftUI
+
+private struct CalagopusServerRow: Identifiable, Hashable {
+    let server: CalagopusServer
+    let resources: CalagopusResources?
+
+    var id: String { server.uuidShort }
+
+    var isRunning: Bool { resources?.state == "running" }
+    var isStarting: Bool { resources?.state == "starting" }
+    var isStopping: Bool { resources?.state == "stopping" }
+}
+
+private struct CalagopusDashboardData: Equatable {
+    let rows: [CalagopusServerRow]
+
+    var runningCount: Int { rows.filter(\.isRunning).count }
+}
+
+struct CalagopusDashboard: View {
+    let instanceId: UUID
+
+    @Environment(ServicesStore.self) private var servicesStore
+    @Environment(Localizer.self) private var localizer
+
+    @State private var selectedInstanceId: UUID
+    @State private var dashboard: CalagopusDashboardData?
+    @State private var state: LoadableState<Void> = .idle
+    @State private var actionServerId: String?
+    @State private var actionErrorMessage: String?
+
+    private let accentColor = ServiceType.calagopus.colors.primary
+    private let twoColumnGrid = [GridItem(.flexible()), GridItem(.flexible())]
+    private let actionGrid = [GridItem(.adaptive(minimum: 132), spacing: 8)]
+
+    init(instanceId: UUID) {
+        self.instanceId = instanceId
+        _selectedInstanceId = State(initialValue: instanceId)
+    }
+
+    var body: some View {
+        ServiceDashboardLayout(
+            serviceType: .calagopus,
+            instanceId: selectedInstanceId,
+            state: state,
+            onRefresh: fetchDashboard
+        ) {
+            instancePicker
+
+            if let dashboard {
+                overviewSection(dashboard)
+
+                if dashboard.rows.isEmpty {
+                    Text(localizer.t.calagopusNoServers)
+                        .font(.subheadline)
+                        .foregroundStyle(AppTheme.textSecondary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(16)
+                        .glassCard()
+                } else {
+                    ForEach(dashboard.rows) { row in
+                        serverCard(row)
+                    }
+                }
+            }
+        }
+        .navigationTitle(ServiceType.calagopus.displayName)
+        .task(id: selectedInstanceId) {
+            await fetchDashboard()
+        }
+    }
+
+    // MARK: - Instance Picker
+
+    private var instancePicker: some View {
+        let instances = servicesStore.instances(for: .calagopus)
+        return Group {
+            if instances.count > 1 {
+                VStack(alignment: .leading, spacing: 12) {
+                    Text(localizer.t.dashboardInstances)
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(AppTheme.textMuted)
+                        .textCase(.uppercase)
+
+                    ForEach(instances) { instance in
+                        Button {
+                            HapticManager.light()
+                            selectedInstanceId = instance.id
+                            servicesStore.setPreferredInstance(id: instance.id, for: .calagopus)
+                            dashboard = nil
+                        } label: {
+                            HStack(spacing: 10) {
+                                Circle()
+                                    .fill(instance.id == selectedInstanceId ? accentColor : AppTheme.textMuted.opacity(0.4))
+                                    .frame(width: 10, height: 10)
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text(instance.displayLabel)
+                                        .font(.subheadline.weight(.semibold))
+                                    Text(instance.url)
+                                        .font(.caption)
+                                        .foregroundStyle(AppTheme.textMuted)
+                                        .lineLimit(1)
+                                }
+                                Spacer()
+                            }
+                            .padding(14)
+                            .glassCard(tint: instance.id == selectedInstanceId ? accentColor.opacity(0.1) : nil)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Overview
+
+    private func overviewSection(_ dashboard: CalagopusDashboardData) -> some View {
+        LazyVGrid(columns: twoColumnGrid, spacing: AppTheme.gridSpacing) {
+            metricCard(
+                title: localizer.t.calagopusRunningServers,
+                value: "\(dashboard.runningCount)/\(dashboard.rows.count)",
+                icon: "server.rack",
+                tint: accentColor
+            )
+            metricCard(
+                title: localizer.t.calagopusTotalServers,
+                value: "\(dashboard.rows.count)",
+                icon: "square.stack.3d.up.fill",
+                tint: accentColor
+            )
+        }
+    }
+
+    private func metricCard(title: String, value: String, icon: String, tint: Color) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Image(systemName: icon)
+                .foregroundStyle(tint)
+            Text(value)
+                .font(.system(size: 30, weight: .bold))
+            Text(title)
+                .font(.caption)
+                .foregroundStyle(AppTheme.textMuted)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(16)
+        .glassCard(tint: tint.opacity(0.08))
+    }
+
+    // MARK: - Server Card
+
+    private func serverCard(_ row: CalagopusServerRow) -> some View {
+        let res = row.resources
+        let accent = statusColor(for: row)
+        let isTransient = row.isStarting || row.isStopping
+        let isActionRunning = actionServerId == row.server.uuidShort
+        let actionsEnabled = !isActionRunning && !isTransient && !row.server.isSuspended
+
+        return VStack(alignment: .leading, spacing: 14) {
+            HStack(alignment: .top) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(row.server.name)
+                        .font(.headline)
+                    Text(row.server.nodeName)
+                        .font(.caption)
+                        .foregroundStyle(AppTheme.textMuted)
+                }
+                Spacer()
+                Text(statusText(for: row))
+                    .font(.caption.bold())
+                    .foregroundStyle(accent)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 6)
+                    .background(accent.opacity(0.12), in: Capsule())
+
+                if isActionRunning {
+                    ProgressView()
+                        .controlSize(.small)
+                        .padding(.top, 4)
+                }
+            }
+
+            LazyVGrid(columns: twoColumnGrid, spacing: 12) {
+                detailPill(
+                    title: localizer.t.calagopusCPU,
+                    value: res.map { String(format: "%.1f%%", $0.cpuAbsolute) } ?? localizer.t.notAvailable,
+                    icon: "speedometer"
+                )
+                detailPill(
+                    title: localizer.t.calagopusRAM,
+                    value: res.map { formatBytes($0.memoryBytes) } ?? localizer.t.notAvailable,
+                    icon: "memorychip"
+                )
+                detailPill(
+                    title: localizer.t.calagopusDisk,
+                    value: res.map { formatBytes($0.diskBytes) } ?? localizer.t.notAvailable,
+                    icon: "internaldrive"
+                )
+                detailPill(
+                    title: localizer.t.calagopusUptime,
+                    value: res.map { formatUptime($0.uptime) } ?? localizer.t.notAvailable,
+                    icon: "clock"
+                )
+            }
+
+            if let desc = row.server.description, !desc.isEmpty {
+                Text(desc)
+                    .font(.caption)
+                    .foregroundStyle(AppTheme.textMuted)
+                    .lineLimit(2)
+            }
+
+            LazyVGrid(columns: actionGrid, spacing: 8) {
+                actionButton(
+                    title: localizer.t.actionStart,
+                    icon: "play.fill",
+                    enabled: actionsEnabled && !row.isRunning,
+                    primary: true
+                ) {
+                    await performPower(.start, uuidShort: row.server.uuidShort)
+                }
+                actionButton(
+                    title: localizer.t.actionStop,
+                    icon: "stop.fill",
+                    enabled: actionsEnabled && row.isRunning
+                ) {
+                    await performPower(.stop, uuidShort: row.server.uuidShort)
+                }
+                actionButton(
+                    title: localizer.t.actionRestart,
+                    icon: "arrow.clockwise",
+                    enabled: actionsEnabled && row.isRunning
+                ) {
+                    await performPower(.restart, uuidShort: row.server.uuidShort)
+                }
+                actionButton(
+                    title: localizer.t.actionKill,
+                    icon: "exclamationmark.octagon.fill",
+                    enabled: actionsEnabled && row.isRunning,
+                    destructive: true
+                ) {
+                    await performPower(.kill, uuidShort: row.server.uuidShort)
+                }
+            }
+        }
+        .padding(16)
+        .glassCard(tint: accent.opacity(0.06))
+    }
+
+    private func detailPill(title: String, value: String, icon: String) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Image(systemName: icon)
+                .foregroundStyle(accentColor)
+            Text(value)
+                .font(.subheadline.weight(.bold))
+            Text(title)
+                .font(.caption)
+                .foregroundStyle(AppTheme.textMuted)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(12)
+        .background(AppTheme.surface.opacity(0.7), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+    }
+
+    private func actionButton(
+        title: String,
+        icon: String,
+        enabled: Bool,
+        primary: Bool = false,
+        destructive: Bool = false,
+        action: @escaping () async -> Void
+    ) -> some View {
+        Button {
+            HapticManager.light()
+            Task { await action() }
+        } label: {
+            HStack(spacing: 8) {
+                Image(systemName: icon)
+                    .font(.caption.weight(.bold))
+                Text(title)
+                    .font(.subheadline.weight(.semibold))
+                    .multilineTextAlignment(.center)
+                    .lineLimit(2)
+                    .minimumScaleFactor(0.85)
+            }
+            .frame(maxWidth: .infinity, minHeight: 44)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 10)
+            .background(
+                (destructive ? AppTheme.danger : accentColor).opacity(enabled ? (primary ? 0.18 : 0.14) : 0.06),
+                in: RoundedRectangle(cornerRadius: 14, style: .continuous)
+            )
+        }
+        .foregroundStyle(enabled ? (destructive ? AppTheme.danger : accentColor) : AppTheme.textMuted)
+        .disabled(!enabled)
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - Status helpers
+
+    private func statusText(for row: CalagopusServerRow) -> String {
+        if row.server.isSuspended { return localizer.t.calagopusStatusSuspended }
+        guard let res = row.resources else { return localizer.t.calagopusStatusOffline }
+        switch res.state {
+        case "running":  return localizer.t.calagopusStatusRunning
+        case "starting": return localizer.t.calagopusStatusStarting
+        case "stopping": return localizer.t.calagopusStatusStopping
+        default:         return localizer.t.calagopusStatusOffline
+        }
+    }
+
+    private func statusColor(for row: CalagopusServerRow) -> Color {
+        if row.server.isSuspended { return AppTheme.danger }
+        guard let res = row.resources else { return AppTheme.textMuted }
+        switch res.state {
+        case "running":  return AppTheme.running
+        case "starting": return AppTheme.warning
+        case "stopping": return AppTheme.warning
+        default:         return AppTheme.textMuted
+        }
+    }
+
+    // MARK: - Format helpers
+
+    private func formatBytes(_ bytes: Int) -> String {
+        let mb = Double(bytes) / 1_048_576
+        if mb >= 1024 {
+            return String(format: "%.1f GB", mb / 1024)
+        }
+        return String(format: "%.0f MB", mb)
+    }
+
+    private func formatUptime(_ ms: Int) -> String {
+        let seconds = ms / 1000
+        let hours = seconds / 3600
+        let minutes = (seconds % 3600) / 60
+        if hours > 0 {
+            return "\(hours)h \(minutes)m"
+        }
+        return "\(minutes)m"
+    }
+
+    // MARK: - Data fetching
+
+    private func fetchDashboard() async {
+        do {
+            if dashboard == nil {
+                state = .loading
+            }
+
+            guard let client = await servicesStore.calagopusClient(instanceId: selectedInstanceId) else {
+                state = .error(.notConfigured)
+                return
+            }
+
+            let servers = try await client.getServers()
+            var rows: [CalagopusServerRow] = []
+
+            for chunk in servers.chunked(into: 4) {
+                let chunkRows = await withTaskGroup(of: CalagopusServerRow.self) { group in
+                    for server in chunk {
+                        group.addTask {
+                            let resources = try? await client.getServerResources(uuidShort: server.uuidShort)
+                            return CalagopusServerRow(server: server, resources: resources)
+                        }
+                    }
+                    var collected: [CalagopusServerRow] = []
+                    for await row in group {
+                        collected.append(row)
+                    }
+                    return collected
+                }
+                rows.append(contentsOf: chunkRows)
+            }
+
+            withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
+                dashboard = CalagopusDashboardData(rows: rows.sorted { $0.server.name < $1.server.name })
+                state = .loaded(())
+            }
+        } catch let apiError as APIError {
+            if dashboard == nil {
+                state = .error(apiError)
+            }
+        } catch {
+            if dashboard == nil {
+                state = .error(.custom(error.localizedDescription))
+            }
+        }
+    }
+
+    // MARK: - Power actions
+
+    private func performPower(_ signal: CalagopusPowerSignal, uuidShort: String) async {
+        do {
+            actionServerId = uuidShort
+            actionErrorMessage = nil
+            guard let client = await servicesStore.calagopusClient(instanceId: selectedInstanceId) else { return }
+            try await client.sendPowerSignal(uuidShort: uuidShort, signal: signal)
+            HapticManager.success()
+            await syncServerAfterAction(uuidShort: uuidShort, signal: signal)
+        } catch {
+            HapticManager.error()
+            actionErrorMessage = error.localizedDescription
+        }
+        actionServerId = nil
+    }
+
+    private func syncServerAfterAction(uuidShort: String, signal: CalagopusPowerSignal) async {
+        let attempts = signal == .kill ? 3 : 6
+        for attempt in 0..<attempts {
+            if attempt > 0 {
+                try? await Task.sleep(nanoseconds: 1_500_000_000)
+            }
+            guard let client = await servicesStore.calagopusClient(instanceId: selectedInstanceId) else { return }
+            guard let resources = try? await client.getServerResources(uuidShort: uuidShort) else { continue }
+            updateRow(uuidShort: uuidShort, resources: resources)
+        }
+    }
+
+    private func updateRow(uuidShort: String, resources: CalagopusResources) {
+        guard let dashboard else { return }
+        let rows = dashboard.rows.map { row in
+            if row.server.uuidShort == uuidShort {
+                return CalagopusServerRow(server: row.server, resources: resources)
+            }
+            return row
+        }
+        self.dashboard = CalagopusDashboardData(rows: rows)
+    }
+}
+
+private extension Array {
+    func chunked(into size: Int) -> [[Element]] {
+        guard size > 0 else { return [self] }
+        return stride(from: 0, to: count, by: size).map { index in
+            Array(self[index ..< Swift.min(index + size, count)])
+        }
+    }
+}

--- a/HomelabSwift/Homelab/Views/Home/HomeView.swift
+++ b/HomelabSwift/Homelab/Views/Home/HomeView.swift
@@ -329,6 +329,8 @@ struct HomeView: View {
         case .lidarr:            LidarrDashboard(instanceId: route.instanceId)
         case .wakapi:            WakapiDashboard(instanceId: route.instanceId)
         case .proxmox:           ProxmoxDashboard(instanceId: route.instanceId)
+        case .pterodactyl:       PterodactylDashboard(instanceId: route.instanceId)
+        case .calagopus:         CalagopusDashboard(instanceId: route.instanceId)
         case .jellyseerr, .prowlarr, .bazarr, .gluetun, .flaresolverr:
                                  GenericMediaDashboard(serviceType: route.type, instanceId: route.instanceId)
         }
@@ -532,6 +534,16 @@ struct HomeView: View {
                     totalRunning += vms.filter { $0.isRunning }.count + lxcs.filter { $0.isRunning }.count
                 }
                 return ServiceSummaryInfo(value: "\(totalRunning)", subValue: "/ \(totalGuests)", label: localizer.t.proxmoxGuestsRunning)
+            case .pterodactyl:
+                guard let client = await servicesStore.pterodactylClient(instanceId: instanceId) else { return nil }
+                let servers = try await client.getServers()
+                let running = servers.filter { $0.status == nil && !$0.isSuspended && !$0.isInstalling }.count
+                return ServiceSummaryInfo(value: "\(running)", subValue: "/ \(servers.count)", label: localizer.t.pterodactylRunningServers)
+            case .calagopus:
+                guard let client = await servicesStore.calagopusClient(instanceId: instanceId) else { return nil }
+                let servers = try await client.getServers()
+                let running = servers.filter { $0.status == nil && !$0.isSuspended }.count
+                return ServiceSummaryInfo(value: "\(running)", subValue: "/ \(servers.count)", label: localizer.t.calagopusRunningServers)
             default:
                 return nil
             }

--- a/HomelabSwift/Homelab/Views/Pterodactyl/PterodactylDashboard.swift
+++ b/HomelabSwift/Homelab/Views/Pterodactyl/PterodactylDashboard.swift
@@ -1,0 +1,441 @@
+import SwiftUI
+
+private struct PterodactylServerRow: Identifiable, Hashable {
+    let server: PterodactylServer
+    let resources: PterodactylResources?
+
+    var id: String { server.identifier }
+
+    var isRunning: Bool { resources?.currentState == "running" }
+    var isStarting: Bool { resources?.currentState == "starting" }
+    var isStopping: Bool { resources?.currentState == "stopping" }
+}
+
+private struct PterodactylDashboardData: Equatable {
+    let rows: [PterodactylServerRow]
+
+    var runningCount: Int { rows.filter(\.isRunning).count }
+}
+
+struct PterodactylDashboard: View {
+    let instanceId: UUID
+
+    @Environment(ServicesStore.self) private var servicesStore
+    @Environment(Localizer.self) private var localizer
+
+    @State private var selectedInstanceId: UUID
+    @State private var dashboard: PterodactylDashboardData?
+    @State private var state: LoadableState<Void> = .idle
+    @State private var actionServerId: String?
+    @State private var actionErrorMessage: String?
+
+    private let pteroColor = ServiceType.pterodactyl.colors.primary
+    private let twoColumnGrid = [GridItem(.flexible()), GridItem(.flexible())]
+    private let actionGrid = [GridItem(.adaptive(minimum: 132), spacing: 8)]
+
+    init(instanceId: UUID) {
+        self.instanceId = instanceId
+        _selectedInstanceId = State(initialValue: instanceId)
+    }
+
+    var body: some View {
+        ServiceDashboardLayout(
+            serviceType: .pterodactyl,
+            instanceId: selectedInstanceId,
+            state: state,
+            onRefresh: fetchDashboard
+        ) {
+            instancePicker
+
+            if let dashboard {
+                overviewSection(dashboard)
+
+                if dashboard.rows.isEmpty {
+                    Text(localizer.t.pterodactylNoServers)
+                        .font(.subheadline)
+                        .foregroundStyle(AppTheme.textSecondary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(16)
+                        .glassCard()
+                } else {
+                    ForEach(dashboard.rows) { row in
+                        serverCard(row)
+                    }
+                }
+            }
+        }
+        .navigationTitle(ServiceType.pterodactyl.displayName)
+        .task(id: selectedInstanceId) {
+            await fetchDashboard()
+        }
+    }
+
+    // MARK: - Instance Picker
+
+    private var instancePicker: some View {
+        let instances = servicesStore.instances(for: .pterodactyl)
+        return Group {
+            if instances.count > 1 {
+                VStack(alignment: .leading, spacing: 12) {
+                    Text(localizer.t.dashboardInstances)
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(AppTheme.textMuted)
+                        .textCase(.uppercase)
+
+                    ForEach(instances) { instance in
+                        Button {
+                            HapticManager.light()
+                            selectedInstanceId = instance.id
+                            servicesStore.setPreferredInstance(id: instance.id, for: .pterodactyl)
+                            dashboard = nil
+                        } label: {
+                            HStack(spacing: 10) {
+                                Circle()
+                                    .fill(instance.id == selectedInstanceId ? pteroColor : AppTheme.textMuted.opacity(0.4))
+                                    .frame(width: 10, height: 10)
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text(instance.displayLabel)
+                                        .font(.subheadline.weight(.semibold))
+                                    Text(instance.url)
+                                        .font(.caption)
+                                        .foregroundStyle(AppTheme.textMuted)
+                                        .lineLimit(1)
+                                }
+                                Spacer()
+                            }
+                            .padding(14)
+                            .glassCard(tint: instance.id == selectedInstanceId ? pteroColor.opacity(0.1) : nil)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Overview
+
+    private func overviewSection(_ dashboard: PterodactylDashboardData) -> some View {
+        LazyVGrid(columns: twoColumnGrid, spacing: AppTheme.gridSpacing) {
+            metricCard(
+                title: localizer.t.pterodactylRunningServers,
+                value: "\(dashboard.runningCount)/\(dashboard.rows.count)",
+                icon: "server.rack",
+                tint: pteroColor
+            )
+            metricCard(
+                title: localizer.t.pterodactylTotalServers,
+                value: "\(dashboard.rows.count)",
+                icon: "square.stack.3d.up.fill",
+                tint: pteroColor
+            )
+        }
+    }
+
+    private func metricCard(title: String, value: String, icon: String, tint: Color) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Image(systemName: icon)
+                .foregroundStyle(tint)
+            Text(value)
+                .font(.system(size: 30, weight: .bold))
+            Text(title)
+                .font(.caption)
+                .foregroundStyle(AppTheme.textMuted)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(16)
+        .glassCard(tint: tint.opacity(0.08))
+    }
+
+    // MARK: - Server Card
+
+    private func serverCard(_ row: PterodactylServerRow) -> some View {
+        let res = row.resources
+        let accent = statusColor(for: row)
+        let isTransient = row.isStarting || row.isStopping
+        let isActionRunning = actionServerId == row.server.identifier
+        let actionsEnabled = !isActionRunning && !isTransient && !row.server.isSuspended
+
+        return VStack(alignment: .leading, spacing: 14) {
+            HStack(alignment: .top) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(row.server.name)
+                        .font(.headline)
+                    Text(row.server.node)
+                        .font(.caption)
+                        .foregroundStyle(AppTheme.textMuted)
+                }
+                Spacer()
+                Text(statusText(for: row))
+                    .font(.caption.bold())
+                    .foregroundStyle(accent)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 6)
+                    .background(accent.opacity(0.12), in: Capsule())
+
+                if isActionRunning {
+                    ProgressView()
+                        .controlSize(.small)
+                        .padding(.top, 4)
+                }
+            }
+
+            LazyVGrid(columns: twoColumnGrid, spacing: 12) {
+                detailPill(
+                    title: localizer.t.pterodactylCPU,
+                    value: res.map { String(format: "%.1f%%", $0.resources.cpuAbsolute) } ?? localizer.t.notAvailable,
+                    icon: "speedometer"
+                )
+                detailPill(
+                    title: localizer.t.pterodactylRAM,
+                    value: res.map { formatBytes($0.resources.memoryBytes) } ?? localizer.t.notAvailable,
+                    icon: "memorychip"
+                )
+                detailPill(
+                    title: localizer.t.pterodactylDisk,
+                    value: res.map { formatBytes($0.resources.diskBytes) } ?? localizer.t.notAvailable,
+                    icon: "internaldrive"
+                )
+                detailPill(
+                    title: localizer.t.pterodactylUptime,
+                    value: res.map { formatUptime($0.resources.uptime) } ?? localizer.t.notAvailable,
+                    icon: "clock"
+                )
+            }
+
+            if !row.server.description.isEmpty {
+                Text(row.server.description)
+                    .font(.caption)
+                    .foregroundStyle(AppTheme.textMuted)
+                    .lineLimit(2)
+            }
+
+            LazyVGrid(columns: actionGrid, spacing: 8) {
+                actionButton(
+                    title: localizer.t.actionStart,
+                    icon: "play.fill",
+                    enabled: actionsEnabled && !row.isRunning,
+                    primary: true
+                ) {
+                    await performPower(.start, identifier: row.server.identifier)
+                }
+                actionButton(
+                    title: localizer.t.actionStop,
+                    icon: "stop.fill",
+                    enabled: actionsEnabled && row.isRunning
+                ) {
+                    await performPower(.stop, identifier: row.server.identifier)
+                }
+                actionButton(
+                    title: localizer.t.actionRestart,
+                    icon: "arrow.clockwise",
+                    enabled: actionsEnabled && row.isRunning
+                ) {
+                    await performPower(.restart, identifier: row.server.identifier)
+                }
+                actionButton(
+                    title: localizer.t.actionKill,
+                    icon: "exclamationmark.octagon.fill",
+                    enabled: actionsEnabled && row.isRunning,
+                    destructive: true
+                ) {
+                    await performPower(.kill, identifier: row.server.identifier)
+                }
+            }
+        }
+        .padding(16)
+        .glassCard(tint: accent.opacity(0.06))
+    }
+
+    private func detailPill(title: String, value: String, icon: String) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Image(systemName: icon)
+                .foregroundStyle(pteroColor)
+            Text(value)
+                .font(.subheadline.weight(.bold))
+            Text(title)
+                .font(.caption)
+                .foregroundStyle(AppTheme.textMuted)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(12)
+        .background(AppTheme.surface.opacity(0.7), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+    }
+
+    private func actionButton(
+        title: String,
+        icon: String,
+        enabled: Bool,
+        primary: Bool = false,
+        destructive: Bool = false,
+        action: @escaping () async -> Void
+    ) -> some View {
+        Button {
+            HapticManager.light()
+            Task { await action() }
+        } label: {
+            HStack(spacing: 8) {
+                Image(systemName: icon)
+                    .font(.caption.weight(.bold))
+                Text(title)
+                    .font(.subheadline.weight(.semibold))
+                    .multilineTextAlignment(.center)
+                    .lineLimit(2)
+                    .minimumScaleFactor(0.85)
+            }
+            .frame(maxWidth: .infinity, minHeight: 44)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 10)
+            .background(
+                (destructive ? AppTheme.danger : pteroColor).opacity(enabled ? (primary ? 0.18 : 0.14) : 0.06),
+                in: RoundedRectangle(cornerRadius: 14, style: .continuous)
+            )
+        }
+        .foregroundStyle(enabled ? (destructive ? AppTheme.danger : pteroColor) : AppTheme.textMuted)
+        .disabled(!enabled)
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - Status helpers
+
+    private func statusText(for row: PterodactylServerRow) -> String {
+        if row.server.isSuspended { return localizer.t.pterodactylStatusSuspended }
+        if row.server.isInstalling { return localizer.t.pterodactylStatusInstalling }
+        guard let res = row.resources else { return localizer.t.pterodactylStatusOffline }
+        switch res.currentState {
+        case "running":  return localizer.t.pterodactylStatusRunning
+        case "starting": return localizer.t.pterodactylStatusStarting
+        case "stopping": return localizer.t.pterodactylStatusStopping
+        default:         return localizer.t.pterodactylStatusOffline
+        }
+    }
+
+    private func statusColor(for row: PterodactylServerRow) -> Color {
+        if row.server.isSuspended { return AppTheme.danger }
+        if row.server.isInstalling { return AppTheme.warning }
+        guard let res = row.resources else { return AppTheme.textMuted }
+        switch res.currentState {
+        case "running":  return AppTheme.running
+        case "starting": return AppTheme.warning
+        case "stopping": return AppTheme.warning
+        default:         return AppTheme.textMuted
+        }
+    }
+
+    // MARK: - Format helpers
+
+    private func formatBytes(_ bytes: Int) -> String {
+        let mb = Double(bytes) / 1_048_576
+        if mb >= 1024 {
+            return String(format: "%.1f GB", mb / 1024)
+        }
+        return String(format: "%.0f MB", mb)
+    }
+
+    private func formatUptime(_ ms: Int) -> String {
+        let seconds = ms / 1000
+        let hours = seconds / 3600
+        let minutes = (seconds % 3600) / 60
+        if hours > 0 {
+            return "\(hours)h \(minutes)m"
+        }
+        return "\(minutes)m"
+    }
+
+    // MARK: - Data fetching
+
+    private func fetchDashboard() async {
+        do {
+            if dashboard == nil {
+                state = .loading
+            }
+
+            guard let client = await servicesStore.pterodactylClient(instanceId: selectedInstanceId) else {
+                state = .error(.notConfigured)
+                return
+            }
+
+            let servers = try await client.getServers()
+            var rows: [PterodactylServerRow] = []
+
+            for chunk in servers.chunked(into: 4) {
+                let chunkRows = await withTaskGroup(of: PterodactylServerRow.self) { group in
+                    for server in chunk {
+                        group.addTask {
+                            let resources = try? await client.getServerResources(identifier: server.identifier)
+                            return PterodactylServerRow(server: server, resources: resources)
+                        }
+                    }
+                    var collected: [PterodactylServerRow] = []
+                    for await row in group {
+                        collected.append(row)
+                    }
+                    return collected
+                }
+                rows.append(contentsOf: chunkRows)
+            }
+
+            withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
+                dashboard = PterodactylDashboardData(rows: rows.sorted { $0.server.name < $1.server.name })
+                state = .loaded(())
+            }
+        } catch let apiError as APIError {
+            if dashboard == nil {
+                state = .error(apiError)
+            }
+        } catch {
+            if dashboard == nil {
+                state = .error(.custom(error.localizedDescription))
+            }
+        }
+    }
+
+    // MARK: - Power actions
+
+    private func performPower(_ signal: PterodactylPowerSignal, identifier: String) async {
+        do {
+            actionServerId = identifier
+            actionErrorMessage = nil
+            guard let client = await servicesStore.pterodactylClient(instanceId: selectedInstanceId) else { return }
+            try await client.sendPowerSignal(identifier: identifier, signal: signal)
+            HapticManager.success()
+            await syncServerAfterAction(identifier: identifier, signal: signal)
+        } catch {
+            HapticManager.error()
+            actionErrorMessage = error.localizedDescription
+        }
+        actionServerId = nil
+    }
+
+    private func syncServerAfterAction(identifier: String, signal: PterodactylPowerSignal) async {
+        let attempts = signal == .kill ? 3 : 6
+        for attempt in 0..<attempts {
+            if attempt > 0 {
+                try? await Task.sleep(nanoseconds: 1_500_000_000)
+            }
+            guard let client = await servicesStore.pterodactylClient(instanceId: selectedInstanceId) else { return }
+            guard let resources = try? await client.getServerResources(identifier: identifier) else { continue }
+            updateRow(identifier: identifier, resources: resources)
+        }
+    }
+
+    private func updateRow(identifier: String, resources: PterodactylResources) {
+        guard let dashboard else { return }
+        let rows = dashboard.rows.map { row in
+            if row.server.identifier == identifier {
+                return PterodactylServerRow(server: row.server, resources: resources)
+            }
+            return row
+        }
+        self.dashboard = PterodactylDashboardData(rows: rows)
+    }
+}
+
+private extension Array {
+    func chunked(into size: Int) -> [[Element]] {
+        guard size > 0 else { return [self] }
+        return stride(from: 0, to: count, by: size).map { index in
+            Array(self[index ..< Swift.min(index + size, count)])
+        }
+    }
+}

--- a/HomelabSwift/Homelab/Views/ServiceLogin/ServiceLoginView.swift
+++ b/HomelabSwift/Homelab/Views/ServiceLogin/ServiceLoginView.swift
@@ -67,6 +67,8 @@ struct ServiceLoginView: View {
             || serviceType == .prowlarr
             || serviceType == .bazarr
             || serviceType == .wakapi
+            || serviceType == .pterodactyl
+            || serviceType == .calagopus
     }
 
     private var usesKomodoAuth: Bool {
@@ -485,6 +487,8 @@ struct ServiceLoginView: View {
                                  return localizer.t.loginHintFlaresolverr
         case .wakapi:            return localizer.t.loginHintWakapi
         case .proxmox:           return localizer.t.loginHintProxmox
+        case .pterodactyl:       return localizer.t.loginHintPterodactyl
+        case .calagopus:         return localizer.t.loginHintCalagopus
         case .qbittorrent, .radarr, .sonarr, .lidarr, .jellyseerr, .prowlarr, .bazarr:
                                  return nil
         default: return nil
@@ -728,6 +732,46 @@ struct ServiceLoginView: View {
             return ServiceInstance(
                 id: existingInstanceId ?? UUID(),
                 type: .wakapi,
+                label: label,
+                url: url,
+                token: "",
+                username: existingInstance?.username,
+                apiKey: key,
+                fallbackUrl: fallbackUrl,
+                allowSelfSigned: allowSelfSigned
+            )
+
+        case .pterodactyl:
+            let key = normalizedOptional(apiKey) ?? existingInstance?.apiKey
+            guard let key, !key.isEmpty else {
+                throw APIError.custom(localizer.t.loginErrorCredentials)
+            }
+            let client = PterodactylAPIClient(instanceId: existingInstanceId ?? UUID())
+            await client.configure(url: url, apiKey: key, fallbackUrl: fallbackUrl, allowSelfSigned: allowSelfSigned)
+            try await client.authenticate(url: url, apiKey: key, fallbackUrl: fallbackUrl)
+            return ServiceInstance(
+                id: existingInstanceId ?? UUID(),
+                type: .pterodactyl,
+                label: label,
+                url: url,
+                token: "",
+                username: existingInstance?.username,
+                apiKey: key,
+                fallbackUrl: fallbackUrl,
+                allowSelfSigned: allowSelfSigned
+            )
+
+        case .calagopus:
+            let key = normalizedOptional(apiKey) ?? existingInstance?.apiKey
+            guard let key, !key.isEmpty else {
+                throw APIError.custom(localizer.t.loginErrorCredentials)
+            }
+            let client = CalagopusAPIClient(instanceId: existingInstanceId ?? UUID())
+            await client.configure(url: url, apiKey: key, fallbackUrl: fallbackUrl, allowSelfSigned: allowSelfSigned)
+            try await client.authenticate(url: url, apiKey: key, fallbackUrl: fallbackUrl)
+            return ServiceInstance(
+                id: existingInstanceId ?? UUID(),
+                type: .calagopus,
                 label: label,
                 url: url,
                 token: "",

--- a/HomelabSwift/Homelab/Views/Settings/BackupView.swift
+++ b/HomelabSwift/Homelab/Views/Settings/BackupView.swift
@@ -481,6 +481,8 @@ struct BackupView: View {
         case .flaresolverr: return localizer.t.serviceFlaresolverr
         case .wakapi: return localizer.t.serviceWakapi
         case .proxmox: return localizer.t.serviceProxmox
+        case .pterodactyl: return ServiceType.pterodactyl.displayName
+        case .calagopus: return ServiceType.calagopus.displayName
         }
     }
 


### PR DESCRIPTION
This MR was written by an ai, I am a developer but not an ios or android one

## iOS (Swift)
- Add CalagopusAPIClient and PterodactylAPIClient (actor-based, Bearer API key auth)
- Add CalagopusDashboard and PterodactylDashboard SwiftUI screens with server power controls (start/stop/restart/kill), CPU/RAM/disk/uptime stats, and status badges
- Add ServiceType.calagopus and ServiceType.pterodactyl cases with all required switch arms (displayName, colors, icons, localization, backup keys)
- Wire navigation in HomeView and fetchSummary for both services
- Update ServiceLoginView (API key auth), ServicesStore, BackupModels, BackupView
- Add full localization for 5 languages (EN/IT/FR/ES/DE)
- Regenerate Xcode project via xcodegen

## Android (Kotlin)
- Add PterodactylApi / CalagopusApi Retrofit interfaces
- Add PterodactylDto / CalagopusDto model classes
- Add PterodactylRepository / CalagopusRepository with Bearer auth and TlsClientSelector support
- Add PterodactylViewModel / CalagopusViewModel with pull-to-refresh, per-server resource polling, and power signal dispatch
- Add PterodactylDashboardScreen / CalagopusDashboardScreen (Compose) with FlowRow resource chips, status dot, and action buttons
- Register API providers in NetworkModule (Hilt)
- Add Bearer auth headers in AuthInterceptor for both service types
- Extend ServiceType enum with PTERODACTYL and CALAGOPUS cases
- Update BackupServiceTypeMapper, SseClient, ServiceTypeExt (colors/icons), ConfiguredServicesScreen, BackupScreen, ServiceLoginViewModel, ServiceLoginScreen login hints, HomeViewModel summary fetching, AppNavigation
- Add string resources (EN) for both services

Calagopus API differences from Pterodactyl:
- Flat response: { servers: { data: [...] } } (no attributes wrapper)
- Server identifier is uuid_short
- Resource state field is 'state' (not 'current_state')
- Resources under resources.* directly (no attributes wrapper)